### PR TITLE
MAIN-T-95 Do not access token for anonymous requests

### DIFF
--- a/server/src/main/java/org/hkurh/doky/security/JwtAuthorizationFilter.kt
+++ b/server/src/main/java/org/hkurh/doky/security/JwtAuthorizationFilter.kt
@@ -20,10 +20,18 @@ import java.io.IOException
 @Component
 class JwtAuthorizationFilter(private val userService: UserService) : OncePerRequestFilter() {
     private val authorizationHeader = "Authorization"
+    private val anonymousEndpoints = arrayOf("/register", "/login")
 
     @Throws(ServletException::class, IOException::class)
     override fun doFilterInternal(request: HttpServletRequest, response: HttpServletResponse, filterChain: FilterChain) {
         LOG.debug("Jwt Authorization Filter is invoked.")
+
+        if (anonymousEndpoints.contains(request.requestURI)) {
+            LOG.debug("No check token for request ${request.requestURI}")
+            filterChain.doFilter(request, response)
+            return
+        }
+
         try {
             val token = getTokenFromRequest(request)
             if (token != null) {


### PR DESCRIPTION
When request is for endpoints that should be accessed only by anonymous user, token is not checked at all.
It is needed when user's browser contains a expired token and it tries to login or register.