### PR TITLE
MAIN-T-117 Create endpoint to send Restore Password email

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ bin
 
 /doky-*.env
 /logs/
+/.run/

--- a/server/src/apiTest/java/org/hkurh/doky/PasswordSpec.kt
+++ b/server/src/apiTest/java/org/hkurh/doky/PasswordSpec.kt
@@ -5,7 +5,6 @@ import org.hkurh.doky.password.api.ResetPasswordRequest
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
-import org.springframework.test.context.jdbc.Sql
 
 @DisplayName("Password API test")
 class PasswordSpec : RestSpec() {

--- a/server/src/apiTest/java/org/hkurh/doky/PasswordSpec.kt
+++ b/server/src/apiTest/java/org/hkurh/doky/PasswordSpec.kt
@@ -1,0 +1,50 @@
+package org.hkurh.doky
+
+import io.restassured.RestAssured.given
+import org.hkurh.doky.password.api.ResetPasswordRequest
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.test.context.jdbc.Sql
+
+@DisplayName("Password API test")
+class PasswordSpec : RestSpec() {
+
+    private val endpoint = "/password"
+    private val resetEndpoint = "$endpoint/reset"
+    private val nonExistUserEmail = "test-no-registered@test.com"
+
+
+    @Test
+    @DisplayName("Should return Not Fount if no user with provided email")
+    fun shouldReturnNotFount_whenNoUserWithProvidedEmail() {
+        // given
+        val requestBody = ResetPasswordRequest().apply {
+            email = nonExistUserEmail
+        }
+        val requestSpec = prepareRequestSpec().setBody(requestBody).build()
+
+        // when
+        val response = given(requestSpec).post(resetEndpoint)
+
+        // then
+        response.then().statusCode(HttpStatus.NOT_FOUND.value())
+    }
+
+    @Test
+    @DisplayName("Should process if user with provided email exists")
+    fun shouldProcess_whenUserExists() {
+        // given
+        val requestBody = ResetPasswordRequest().apply {
+            email = validUserUid
+        }
+        val requestSpec = prepareRequestSpec().setBody(requestBody).build()
+
+        // when
+        val response = given(requestSpec).post(resetEndpoint)
+
+        // then
+        response.then().statusCode(HttpStatus.NO_CONTENT.value())
+    }
+
+}

--- a/server/src/apiTest/java/org/hkurh/doky/RestSpec.kt
+++ b/server/src/apiTest/java/org/hkurh/doky/RestSpec.kt
@@ -3,6 +3,8 @@ package org.hkurh.doky
 import io.restassured.RestAssured.given
 import io.restassured.builder.RequestSpecBuilder
 import org.hkurh.doky.authorization.AuthenticationRequest
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -11,6 +13,7 @@ import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.context.jdbc.SqlMergeMode
+import org.springframework.transaction.annotation.Transactional
 
 @ActiveProfiles("test")
 @Tag("api")

--- a/server/src/apiTest/resources/sql/DocumentSpec/setup.sql
+++ b/server/src/apiTest/resources/sql/DocumentSpec/setup.sql
@@ -1,13 +1,13 @@
-insert into document (name, description, file_name, created_date, modified_date, creator_id  )
+replace into document (name, description, file_name, created_date, modified_date, creator_id  )
 select "Test_1", "That is a test document", "test.txt", '2024-01-15 13:00:00', '2024-01-15 13:00:00', u.id from user u where u.uid = "hanna_test_1@example.com";
 
-insert into document (name, description, created_date, modified_date, creator_id )
+replace into document (name, description, created_date, modified_date, creator_id )
 select "Test_2", "That is a second test document", '2024-01-15 16:00:00', '2024-01-15 16:00:00', u.id from user u where u.uid = "hanna_test_1@example.com";
 
-insert into user (uid, name, password) values ( "hanna_test_2@example.com", "Hanna", "$2a$10$bdZSuBncZqaM4XwHcjxbpeQuXeOxk6vCEsFrTwa91xh3M3JpvW41m" );
+replace into user (uid, name, password) values ( "hanna_test_2@example.com", "Hanna", "$2a$10$bdZSuBncZqaM4XwHcjxbpeQuXeOxk6vCEsFrTwa91xh3M3JpvW41m" );
 
-insert into document (name, description, created_date, modified_date, creator_id )
+replace into document (name, description, created_date, modified_date, creator_id )
 select "Test_3", "That is a test document", '2024-02-13 13:00:00', '2024-03-15 13:24:00', u.id from user u where u.uid = "hanna_test_2@example.com";
 
-insert into document (name, description, created_date, modified_date, creator_id )
+replace into document (name, description, created_date, modified_date, creator_id )
 select "Test_4", "That is a second test document", '2024-01-15 13:00:00', '2024-01-15 13:00:00', u.id from user u where u.uid = "hanna_test_2@example.com";

--- a/server/src/apiTest/resources/sql/SearchSpec/setup.sql
+++ b/server/src/apiTest/resources/sql/SearchSpec/setup.sql
@@ -1,13 +1,13 @@
-insert into document (name, description, file_name, created_date, modified_date, creator_id  )
+replace into document (name, description, file_name, created_date, modified_date, creator_id  )
 select "Test note 1", "That is a test document", "test.txt", '2024-01-15 13:00:00', '2024-01-15 13:00:00', u.id from user u where u.uid = "hanna_test_1@example.com";
 
-insert into document (name, description, created_date, modified_date, creator_id )
+replace into document (name, description, created_date, modified_date, creator_id )
 select "Lorem", "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed vitae augue et tortor dapibus finibus.", '2024-01-15 16:00:00', '2024-01-15 16:00:00', u.id from user u where u.uid = "hanna_test_1@example.com";
 
-insert into user (uid, name, password) values ( "hanna_test_2@example.com", "Hanna", "$2a$10$bdZSuBncZqaM4XwHcjxbpeQuXeOxk6vCEsFrTwa91xh3M3JpvW41m" );
+replace into user (uid, name, password) values ( "hanna_test_2@example.com", "Hanna", "$2a$10$bdZSuBncZqaM4XwHcjxbpeQuXeOxk6vCEsFrTwa91xh3M3JpvW41m" );
 
-insert into document (name, description, created_date, modified_date, creator_id )
+replace into document (name, description, created_date, modified_date, creator_id )
 select "Test note 2", "That is a test document", '2024-02-13 13:00:00', '2024-03-15 13:24:00', u.id from user u where u.uid = "hanna_test_2@example.com";
 
-insert into document (name, description, created_date, modified_date, creator_id )
+replace into document (name, description, created_date, modified_date, creator_id )
 select "Cras at nulla ex", "Phasellus vestibulum nisl augue, a pharetra nunc molestie ut. Integer mollis ex fringilla vulputate facilisis.", '2024-01-15 13:00:00', '2024-01-15 13:00:00', u.id from user u where u.uid = "hanna_test_2@example.com";

--- a/server/src/apiTest/resources/sql/cleanup_base_test_data.sql
+++ b/server/src/apiTest/resources/sql/cleanup_base_test_data.sql
@@ -1,3 +1,5 @@
 delete d from document d inner join user u on d.creator_id = u.id where u.uid = "hanna_test_1@example.com";
 
+delete from reset_password_token;
+
 delete u from user u where u.uid = "hanna_test_1@example.com";

--- a/server/src/apiTest/resources/sql/create_base_test_data.sql
+++ b/server/src/apiTest/resources/sql/create_base_test_data.sql
@@ -1,1 +1,1 @@
-insert into user (uid, name, password) values ( "hanna_test_1@example.com", "Hanna", "$2a$10$bdZSuBncZqaM4XwHcjxbpeQuXeOxk6vCEsFrTwa91xh3M3JpvW41m" );
+replace into user (uid, name, password) values ( "hanna_test_1@example.com", "Hanna", "$2a$10$bdZSuBncZqaM4XwHcjxbpeQuXeOxk6vCEsFrTwa91xh3M3JpvW41m" );

--- a/server/src/main/java/org/hkurh/doky/email/EmailService.kt
+++ b/server/src/main/java/org/hkurh/doky/email/EmailService.kt
@@ -16,6 +16,9 @@ class EmailService(
     val templateEngine: SpringTemplateEngine
 ) {
 
+    @Value("\${doky.app.host}")
+    lateinit var host: String
+
     @Value("\${doky.email.from}")
     lateinit var fromEmail: String
 
@@ -36,6 +39,28 @@ class EmailService(
             setFrom(fromEmail)
             setTo(user.uid)
             setSubject("Doky Registration")
+            setText(htmlBody, true)
+            addInline("logo-white-no-bg.svg", logoFile)
+        }
+        emailSender.send(message)
+    }
+
+    fun sendRestorePasswordEmail(user: UserEntity, token: String) {
+        val template = "restore-password.html"
+        val variables = HashMap<String, Any>().apply {
+            user.name?.let { put("username", it) }
+            put("restoreLink", "$host/password/update?token=$token")
+            put("mailto", fromEmail)
+        }
+        val context = Context().apply {
+            setVariables(variables)
+        }
+        val htmlBody: String = templateEngine.process(template, context)
+        val message = emailSender.createMimeMessage()
+        MimeMessageHelper(message, true, "UTF-8").apply {
+            setFrom(fromEmail)
+            setTo(user.uid)
+            setSubject("Doky Restore Password")
             setText(htmlBody, true)
             addInline("logo-white-no-bg.svg", logoFile)
         }

--- a/server/src/main/java/org/hkurh/doky/password/PasswordFacade.kt
+++ b/server/src/main/java/org/hkurh/doky/password/PasswordFacade.kt
@@ -3,6 +3,7 @@ package org.hkurh.doky.password
 import org.hkurh.doky.email.EmailService
 import org.hkurh.doky.errorhandling.DokyNotFoundException
 import org.hkurh.doky.users.UserService
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
 @Component
@@ -13,10 +14,20 @@ class PasswordFacade(
 ) {
 
     fun reset(email: String) {
-        if (!userService.exists(email)) throw DokyNotFoundException("User with email $email does not exist")
+        if (!userService.exists(email)) throw DokyNotFoundException("User does not exist")
 
         val user = userService.findUserByUid(email)
         val token = resetPasswordService.generateAndSaveResetToken(user!!)
-        emailService.sendRestorePasswordEmail(user, token)
+        LOG.debug("Generate reset password token for user ${user.id}")
+        try {
+            emailService.sendRestorePasswordEmail(user, token)
+        } catch (e: Exception) {
+            LOG.error("Error sending reset password email for user ${user.id}", e)
+        }
+    }
+
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(PasswordFacade::class.java)
     }
 }

--- a/server/src/main/java/org/hkurh/doky/password/PasswordFacade.kt
+++ b/server/src/main/java/org/hkurh/doky/password/PasswordFacade.kt
@@ -1,0 +1,22 @@
+package org.hkurh.doky.password
+
+import org.hkurh.doky.email.EmailService
+import org.hkurh.doky.errorhandling.DokyNotFoundException
+import org.hkurh.doky.users.UserService
+import org.springframework.stereotype.Component
+
+@Component
+class PasswordFacade(
+    private val userService: UserService,
+    private val resetPasswordService: ResetPasswordService,
+    private val emailService: EmailService
+) {
+
+    fun reset(email: String) {
+        if (!userService.exists(email)) throw DokyNotFoundException("User with email $email does not exist")
+
+        val user = userService.findUserByUid(email)
+        val token = resetPasswordService.generateAndSaveResetToken(user!!)
+        emailService.sendRestorePasswordEmail(user, token)
+    }
+}

--- a/server/src/main/java/org/hkurh/doky/password/ResetPasswordService.kt
+++ b/server/src/main/java/org/hkurh/doky/password/ResetPasswordService.kt
@@ -1,0 +1,28 @@
+package org.hkurh.doky.password
+
+import org.hkurh.doky.password.db.ResetPasswordTokenEntity
+import org.hkurh.doky.password.db.ResetPasswordTokenRepository
+import org.hkurh.doky.users.db.UserEntity
+import org.springframework.stereotype.Service
+
+@Service
+class ResetPasswordService(
+    private var tokenUtil: TokenUtil,
+    private val resetPasswordTokenRepository: ResetPasswordTokenRepository
+) {
+
+    fun generateAndSaveResetToken(user: UserEntity): String {
+        resetPasswordTokenRepository.findByUser(user)?.let {
+            resetPasswordTokenRepository.delete(it)
+        }
+        val token = tokenUtil.generateToken()
+        val expirationDate = tokenUtil.calculateExpirationDate()
+        val resetPasswordTokenEntity = ResetPasswordTokenEntity().apply {
+            this.token = token
+            this.user = user
+            this.expirationDate = expirationDate
+        }
+        val savedPasswordTokenEntity = resetPasswordTokenRepository.save(resetPasswordTokenEntity)
+        return savedPasswordTokenEntity.token!!
+    }
+}

--- a/server/src/main/java/org/hkurh/doky/password/TokenUtil.kt
+++ b/server/src/main/java/org/hkurh/doky/password/TokenUtil.kt
@@ -1,0 +1,28 @@
+package org.hkurh.doky.password
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.util.*
+
+@Component
+class TokenUtil {
+
+    private val zoneId = ZoneId.of("UTC")
+
+    @Value("\${doky.password.reset.token.duration}")
+    var resetTokenDuration: Long = 10
+
+    fun calculateExpirationDate(): Date {
+        val currentDate = LocalDateTime.ofInstant(Instant.now(), zoneId)
+        val expiredDate = currentDate.plusMinutes(resetTokenDuration)
+        return Date.from(expiredDate.toInstant(ZoneOffset.UTC))
+    }
+
+    fun generateToken() : String {
+        return UUID.randomUUID().toString()
+    }
+}

--- a/server/src/main/java/org/hkurh/doky/password/api/PasswordApi.kt
+++ b/server/src/main/java/org/hkurh/doky/password/api/PasswordApi.kt
@@ -1,0 +1,26 @@
+package org.hkurh.doky.password.api
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.RequestBody
+
+@Tag(name = "Password")
+@SecurityRequirement(name = "Bearer Token")
+interface PasswordApi {
+
+
+    @Operation(summary = "Send a request (email) to restore password for user")
+    @ApiResponses(
+        ApiResponse(responseCode = "204", description = "Reset password request is applied successfully"),
+        ApiResponse(responseCode = "404", description = "There no registered user with provided email"),
+        ApiResponse(responseCode = "400", description = "Provided email is null, empty or has incorrect format")
+    )
+    fun reset(@RequestBody resetPasswordRequest: ResetPasswordRequest): ResponseEntity<Any>
+}

--- a/server/src/main/java/org/hkurh/doky/password/api/PasswordController.kt
+++ b/server/src/main/java/org/hkurh/doky/password/api/PasswordController.kt
@@ -1,0 +1,22 @@
+package org.hkurh.doky.password.api
+
+import jakarta.validation.Valid
+import org.hkurh.doky.password.PasswordFacade
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/password")
+class PasswordController(
+    val passwordFacade: PasswordFacade
+) : PasswordApi {
+
+    @PostMapping("/reset")
+    override fun reset(@RequestBody @Valid resetPasswordRequest: ResetPasswordRequest): ResponseEntity<Any> {
+        passwordFacade.reset(resetPasswordRequest.email)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/server/src/main/java/org/hkurh/doky/password/api/ResetPasswordRequest.kt
+++ b/server/src/main/java/org/hkurh/doky/password/api/ResetPasswordRequest.kt
@@ -1,0 +1,15 @@
+package org.hkurh.doky.password.api
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
+
+class ResetPasswordRequest {
+    @NotBlank(message = "Email is required")
+    @Size(min = 4, max = 32, message = "Length should be from 4 to 32 characters")
+    @Pattern(
+        regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,6}\$",
+        message = "Should be an valid email address"
+    )
+    var email: String = ""
+}

--- a/server/src/main/java/org/hkurh/doky/password/db/ResetPasswordTokenEntity.kt
+++ b/server/src/main/java/org/hkurh/doky/password/db/ResetPasswordTokenEntity.kt
@@ -1,0 +1,38 @@
+package org.hkurh.doky.password.db
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import org.hkurh.doky.users.db.UserEntity
+import java.util.*
+
+@Entity
+@Table(
+    name = "reset_password_token",
+    indexes = [Index(name = "idx_reset_password_token_token", columnList = "token")],
+    uniqueConstraints = [UniqueConstraint(name = "uq_reset_password_token_token", columnNames = ["token"])]
+)
+class ResetPasswordTokenEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    var id: Long = -1
+
+    @OneToOne
+    @JoinColumn(name = "user")
+    var user: UserEntity? = null
+
+    @Column(name = "token")
+    var token: String? = null
+
+    @Column(name = "expiration_date")
+    var expirationDate: Date? = null
+}

--- a/server/src/main/java/org/hkurh/doky/password/db/ResetPasswordTokenRepository.kt
+++ b/server/src/main/java/org/hkurh/doky/password/db/ResetPasswordTokenRepository.kt
@@ -1,0 +1,12 @@
+package org.hkurh.doky.password.db
+
+import org.hkurh.doky.users.db.UserEntity
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor
+import org.springframework.data.repository.CrudRepository
+
+
+interface ResetPasswordTokenRepository :
+    CrudRepository<ResetPasswordTokenEntity, Long>, JpaSpecificationExecutor<ResetPasswordTokenEntity> {
+
+        fun findByUser(user: UserEntity): ResetPasswordTokenEntity?
+    }

--- a/server/src/main/java/org/hkurh/doky/security/JwtAuthorizationFilter.kt
+++ b/server/src/main/java/org/hkurh/doky/security/JwtAuthorizationFilter.kt
@@ -18,7 +18,7 @@ import java.io.IOException
 @Component
 class JwtAuthorizationFilter(private val userService: UserService) : OncePerRequestFilter() {
     private val authorizationHeader = "Authorization"
-    private val anonymousEndpoints = arrayOf("/register", "/login")
+    private val anonymousEndpoints = arrayOf("/register", "/login", "/password/reset")
 
     @Throws(ServletException::class, IOException::class)
     override fun doFilterInternal(

--- a/server/src/main/java/org/hkurh/doky/users/UserFacade.kt
+++ b/server/src/main/java/org/hkurh/doky/users/UserFacade.kt
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component
 @Component
 class UserFacade(private val userService: UserService, private val passwordEncoder: PasswordEncoder) {
     fun checkCredentials(userUid: String, password: String) {
-        if (!userService.checkUserExistence(userUid)) throw DokyAuthenticationException("User doesn't exist")
+        if (!userService.exists(userUid)) throw DokyAuthenticationException("User doesn't exist")
         val userEntity = userService.findUserByUid(userUid)
         val encodedPassword = userEntity!!.password
         if (!passwordEncoder.matches(password, encodedPassword))
@@ -20,7 +20,7 @@ class UserFacade(private val userService: UserService, private val passwordEncod
     }
 
     fun register(userUid: String, password: String): UserDto {
-        if (userService.checkUserExistence(userUid)) throw DokyRegistrationException("User already exists")
+        if (userService.exists(userUid)) throw DokyRegistrationException("User already exists")
         val encodedPassword = passwordEncoder.encode(password)
         val userEntity = userService.create(userUid, encodedPassword)
         LOG.info("Register new user $userEntity")

--- a/server/src/main/java/org/hkurh/doky/users/UserService.kt
+++ b/server/src/main/java/org/hkurh/doky/users/UserService.kt
@@ -19,11 +19,6 @@ class UserService(
         return userEntityRepository.findByUid(userUid) ?: throw DokyNotFoundException("User doesn't exist")
     }
 
-    fun checkUserExistence(userUid: String): Boolean {
-        val userEntity = userEntityRepository.findByUid(userUid)
-        return userEntity != null
-    }
-
     fun create(userUid: String, encodedPassword: String): UserEntity {
         val userEntity = UserEntity()
         userEntity.uid = userUid
@@ -53,6 +48,14 @@ class UserService(
 
     fun extractNameFromUid(userUid: String): String {
         return userUid.split("@").first()
+    }
+
+    fun exists(email: String) : Boolean {
+       return userEntityRepository.existsByUid(email)
+    }
+
+    fun exists(id: Long) : Boolean {
+        return userEntityRepository.existsById(id)
     }
 
     companion object {

--- a/server/src/main/java/org/hkurh/doky/users/db/UserEntityRepository.kt
+++ b/server/src/main/java/org/hkurh/doky/users/db/UserEntityRepository.kt
@@ -6,6 +6,7 @@ import org.springframework.data.repository.CrudRepository
 
 interface UserEntityRepository : CrudRepository<UserEntity?, Long?>, JpaSpecificationExecutor<UserEntity?> {
 
-    @Query("select u from UserEntity u where u.uid = ?1")
     fun findByUid(uid: String): UserEntity?
+
+    fun existsByUid(uid: String): Boolean
 }

--- a/server/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/server/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -74,6 +74,11 @@
       "name": "doky.version.commit",
       "type": "java.lang.String",
       "description": "Description for doky.version.commit."
+    },
+    {
+      "name": "doky.password.reset.token.duration",
+      "type": "java.lang.Long",
+      "description": "Determine how long in minutes token for resetting password is valid."
     }
   ],
   "hints": [

--- a/server/src/main/resources/application-local.properties
+++ b/server/src/main/resources/application-local.properties
@@ -1,5 +1,6 @@
 # local port to start server
 server.port=8119
+doky.app.host=http://localhost:${server.port}
 # database properties
 db.host=localhost
 db.port=3308
@@ -17,3 +18,14 @@ doky.filestorage.path=./doky/filestorage
 doky.filestorage.type=local-filesystem
 # search
 doky.search.solr.core.documents=documents-local
+# emails
+spring.mail.host=localhost
+spring.mail.port=2525
+spring.mail.username=""
+spring.mail.password=""
+
+
+logging.level.web=DEBUG
+logging.level.org.hkurh.doky=DEBUG
+logging.level.org.hkurh.doky.security.JwtAuthorizationFilter=DEBUG
+

--- a/server/src/main/resources/application-test.properties
+++ b/server/src/main/resources/application-test.properties
@@ -1,4 +1,5 @@
 server.port=8181
+doky.app.host=http://localhost:${server.port}
 # database properties
 db.host=localhost
 db.port=3309

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 server.port=8118
+doky.app.host=${WEBSITE_HOSTNAME}
 # swagger
 springdoc.swagger-ui.path=/swagger-ui.html
 springdoc.api-docs.path=/api-docs
@@ -40,3 +41,5 @@ doky.version.commit=${BUILD_COMMIT}
 # security
 spring.security.user.name=user
 spring.security.user.password=${SPRING_USER_PASS}
+# password
+doky.password.reset.token.duration=10

--- a/server/src/main/resources/db/migration/V14__create_reset_password_token.sql
+++ b/server/src/main/resources/db/migration/V14__create_reset_password_token.sql
@@ -1,0 +1,19 @@
+CREATE TABLE reset_password_token
+(
+    id              BIGINT AUTO_INCREMENT NOT NULL,
+    user            BIGINT                NULL,
+    token           VARCHAR(255)          NULL,
+    expiration_date datetime              NULL,
+    CONSTRAINT pk_reset_password_token PRIMARY KEY (id)
+);
+
+ALTER TABLE reset_password_token
+    ADD CONSTRAINT uc_reset_password_token_user UNIQUE (user);
+
+ALTER TABLE reset_password_token
+    ADD CONSTRAINT uq_reset_password_token_token UNIQUE (token);
+
+CREATE INDEX idx_reset_password_token_token ON reset_password_token (token);
+
+ALTER TABLE reset_password_token
+    ADD CONSTRAINT FK_RESET_PASSWORD_TOKEN_ON_USER FOREIGN KEY (user) REFERENCES user (id);

--- a/server/src/main/resources/mail/templates/restore-password.html
+++ b/server/src/main/resources/mail/templates/restore-password.html
@@ -10,7 +10,6 @@
 <!--/*@thymesVar id="username" type="String"*/-->
 <!--/*@thymesVar id="mailto" type="String"*/-->
 <!--/*@thymesVar id="restoreLink" type="String"*/-->
-<!--/*@thymesVar id="token" type="String"*/-->
 
 <div class="d-flex align-items-center justify-content-center">
     <div style="background-color: #07689f; max-width: 100%">

--- a/server/src/main/resources/mail/templates/restore-password.html
+++ b/server/src/main/resources/mail/templates/restore-password.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/html" lang="en">
+<head>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
+          integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>Doky Registration</title>
+</head>
+<body>
+<!--/*@thymesVar id="username" type="String"*/-->
+<!--/*@thymesVar id="mailto" type="String"*/-->
+<!--/*@thymesVar id="restoreLink" type="String"*/-->
+<!--/*@thymesVar id="token" type="String"*/-->
+
+<div class="d-flex align-items-center justify-content-center">
+    <div style="background-color: #07689f; max-width: 100%">
+        <img class="mb-3 mt-3 img-fluid" src="cid:logo-white-no-bg.svg" alt="logo" height="100px"/>
+    </div>
+    <div>
+        <p>Dear <strong th:text="${username}" />,</p>
+        <p>You recently requested to reset your password for your Doky account. Use the button below to reset it:</p>
+
+        <div>
+            <a class="btn btn-primary" th:href="${restoreLink}" role="button">Restore Password</a>
+        </div>
+
+        <p>This password restore link is only valid for the next 24 hours.</p>
+        <p>If you didn't initiate this request or have any concerns, please contact our support team at
+            <a href="mailto:doky-dev@outlook.com"><span th:text="${mailto}" /></a></p>
+        <p>Best regards, The Doky Team</p>
+    </div>
+</div>
+</body>
+</html>

--- a/server/src/test/java/org/hkurh/doky/password/PasswordFacadeTest.kt
+++ b/server/src/test/java/org/hkurh/doky/password/PasswordFacadeTest.kt
@@ -1,0 +1,78 @@
+package org.hkurh.doky.password
+
+import org.hkurh.doky.DokyUnitTest
+import org.hkurh.doky.email.EmailService
+import org.hkurh.doky.errorhandling.DokyNotFoundException
+import org.hkurh.doky.users.UserService
+import org.hkurh.doky.users.db.UserEntity
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.InjectMocks
+import org.mockito.Spy
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.whenever
+
+@DisplayName("PasswordFacadeTest unit test")
+class PasswordFacadeTest : DokyUnitTest {
+
+    @Spy
+    @InjectMocks
+    lateinit var passwordFacade: PasswordFacade
+    private val userService: UserService = mock()
+    private val resetPasswordService: ResetPasswordService = mock()
+    private val emailService: EmailService = mock()
+
+    private val userEmail = "test@example.com"
+    private val generatedToken = "token"
+    private val userEntity = UserEntity().apply {
+        uid = userEmail
+    }
+
+    @Test
+    @DisplayName("Should generate reset password token when user exists")
+    fun shouldGenerateToken_whenUserExists() {
+        // given
+        whenever(userService.exists(userEmail)).thenReturn(true)
+        whenever(userService.findUserByUid(userEmail)).thenReturn(userEntity)
+        whenever(resetPasswordService.generateAndSaveResetToken(userEntity)).thenReturn(generatedToken)
+
+        // when
+        passwordFacade.reset(userEmail)
+
+        // then
+        verify(resetPasswordService, times(1)).generateAndSaveResetToken(userEntity)
+    }
+
+    @Test
+    @DisplayName("Should send email with reset password token when user exists")
+    fun shouldSendEmailWithResetPassword_whenUserExists() {
+        // given
+        whenever(userService.exists(userEmail)).thenReturn(true)
+        whenever(userService.findUserByUid(userEmail)).thenReturn(userEntity)
+        whenever(resetPasswordService.generateAndSaveResetToken(userEntity)).thenReturn(generatedToken)
+
+        // when
+        passwordFacade.reset(userEmail)
+
+        // then
+        verify(emailService, times(1)).sendRestorePasswordEmail(userEntity, generatedToken)
+    }
+
+    @Test
+    @DisplayName("Should throw exception when user doesn't exist")
+    fun shouldThrowException_whenUserDoesNotExist() {
+        // given
+        whenever(userService.exists(userEmail)).thenReturn(false)
+
+        // when - then
+        assertThrows<DokyNotFoundException> { passwordFacade.reset(userEmail) }
+
+        // then
+        verifyNoMoreInteractions(resetPasswordService)
+        verifyNoMoreInteractions(emailService)
+    }
+}

--- a/server/src/test/java/org/hkurh/doky/password/ResetPasswordServiceTest.kt
+++ b/server/src/test/java/org/hkurh/doky/password/ResetPasswordServiceTest.kt
@@ -1,0 +1,85 @@
+package org.hkurh.doky.password
+
+import org.hkurh.doky.DokyUnitTest
+import org.hkurh.doky.password.db.ResetPasswordTokenEntity
+import org.hkurh.doky.password.db.ResetPasswordTokenRepository
+import org.hkurh.doky.users.db.UserEntity
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.*
+
+
+@DisplayName("ResetPasswordService unit test")
+class ResetPasswordServiceTest : DokyUnitTest {
+
+    private var tokenUtil: TokenUtil = mock()
+    private var resetPasswordTokenRepository: ResetPasswordTokenRepository = mock()
+    private var resetPasswordService = ResetPasswordService(tokenUtil, resetPasswordTokenRepository)
+
+    private val mockUser = mock<UserEntity>()
+    private val tokenId: Long = 1
+    private val tokenString = "test-token"
+    private val tokenDate = Date()
+
+    @Test
+    @DisplayName("Should save token info in database")
+    fun shouldSaveTokenInfoInDatabase() {
+        // when
+        whenever(tokenUtil.generateToken()).thenReturn(tokenString)
+        whenever(tokenUtil.calculateExpirationDate()).thenReturn(tokenDate)
+
+        whenever(resetPasswordTokenRepository.save(any<ResetPasswordTokenEntity>())).thenAnswer { invocation ->
+            val argument = invocation.getArgument<ResetPasswordTokenEntity>(0)
+            assertEquals(mockUser, argument.user)
+            assertEquals(tokenString, argument.token)
+            assertEquals(tokenDate, argument.expirationDate)
+            argument.id = tokenId
+            argument
+        }
+
+        // when
+        val token = resetPasswordService.generateAndSaveResetToken(mockUser)
+
+        // then
+        assertEquals(token, tokenString)
+        verify(resetPasswordTokenRepository, times(1)).save(any<ResetPasswordTokenEntity>())
+    }
+
+
+    @Test
+    @DisplayName("Should remove existing token and save new token in database")
+    fun shouldRemoveExistingAndSaveNewTokenInformationInDatabase() {
+        // Given
+        val existingToken = ResetPasswordTokenEntity()
+        existingToken.id = tokenId
+        existingToken.token = "existing-token"
+
+        whenever(tokenUtil.generateToken()).thenReturn(tokenString)
+        whenever(tokenUtil.calculateExpirationDate()).thenReturn(tokenDate)
+        whenever(resetPasswordTokenRepository.findByUser(mockUser)).thenReturn(existingToken)
+
+        whenever(resetPasswordTokenRepository.save(any<ResetPasswordTokenEntity>())).thenAnswer { invocation ->
+            val argument = invocation.getArgument<ResetPasswordTokenEntity>(0)
+            assertEquals(mockUser, argument.user)
+            assertEquals(tokenString, argument.token)
+            assertEquals(tokenDate, argument.expirationDate)
+            argument.id = tokenId
+            argument
+        }
+
+        // When
+        val token = resetPasswordService.generateAndSaveResetToken(mockUser)
+
+        // Then
+        verify(resetPasswordTokenRepository, times(1)).findByUser(mockUser)
+        verify(resetPasswordTokenRepository, times(1)).delete(existingToken)
+
+        assertEquals(token, tokenString)
+    }
+}

--- a/server/src/test/java/org/hkurh/doky/users/UserFacadeTest.kt
+++ b/server/src/test/java/org/hkurh/doky/users/UserFacadeTest.kt
@@ -40,7 +40,7 @@ class UserFacadeTest : DokyUnitTest {
     @DisplayName("Should done without errors when user is valid when login")
     fun shouldSetToken_whenUserIsValid() {
         // given
-        whenever(userService.checkUserExistence(userUid)).thenReturn(true)
+        whenever(userService.exists(userUid)).thenReturn(true)
         whenever(userService.findUserByUid(userUid)).thenReturn(userEntity)
         whenever(passwordEncoder.matches(userPassword, userPasswordEncoded)).thenReturn(true)
 
@@ -52,7 +52,7 @@ class UserFacadeTest : DokyUnitTest {
     @DisplayName("Should throw exception when user login is incorrect when login")
     fun shouldThrowException_whenUserIsIncorrect() {
         // given
-        whenever(userService.checkUserExistence(userUid)).thenReturn(false)
+        whenever(userService.exists(userUid)).thenReturn(false)
 
         // when - then
         assertThrows<DokyAuthenticationException> { userFacade.checkCredentials(userUid, userPassword) }
@@ -62,7 +62,7 @@ class UserFacadeTest : DokyUnitTest {
     @DisplayName("Should throw exception when user exists when register")
     fun shouldThrowException_whenExistingUserRegister() {
         // given
-        whenever(userService.checkUserExistence(userUid)).thenReturn(true)
+        whenever(userService.exists(userUid)).thenReturn(true)
 
         // when - then
         assertThrows<DokyRegistrationException> { userFacade.register(userUid, userPassword) }


### PR DESCRIPTION
Add password reset feature with token generation and email notification

 - Implemented a password reset functionality that checks user existence, generates a reset password token, and sends an email notification with the reset password token.
 - Created relevant test cases and updated user service and user facade.
 - Added endpoint to reset password and updated JwtAuthorizationFilter for password reset endpoint.
 - Included new database table for storing reset password tokens.