### PR TITLE
MAIN-T-124 It's possible to crate document with empty name and description

### DIFF
--- a/.github/workflows/gradle-pr.yml
+++ b/.github/workflows/gradle-pr.yml
@@ -19,11 +19,12 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          args: --project-dir,server,--baseline,qodana.sarif.json
       - name: 'Qodana Scan'
         uses: JetBrains/qodana-action@v2023.3
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
+        with:
+          args: --project-dir,server,--baseline,qodana.sarif.json
 
   unit:
     runs-on: ubuntu-latest

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,0 +1,13 @@
+#-------------------------------------------------------------------------------#
+#               Qodana analysis is configured by qodana.yaml file               #
+#             https://www.jetbrains.com/help/qodana/qodana-yaml.html            #
+#-------------------------------------------------------------------------------#
+version: "1.0"
+projectJDK: "17"
+linter: jetbrains/qodana-jvm:latest
+
+profile:
+  name: qodana.recommended
+
+include:
+  - name: CheckDependencyLicenses

--- a/server/src/apiTest/kotlin/org/hkurh/doky/DocumentSpec.kt
+++ b/server/src/apiTest/kotlin/org/hkurh/doky/DocumentSpec.kt
@@ -63,7 +63,10 @@ class DocumentSpec : RestSpec() {
     @DisplayName("Should create new document")
     fun shouldCreateNewDocument() {
         // given
-        val requestBody = DocumentRequest(newDocumentName, newDocumentDescription)
+        val requestBody = DocumentRequest().apply {
+            name = newDocumentName
+            description = newDocumentDescription
+        }
         val requestSpec = prepareRequestSpecWithLogin().setBody(requestBody).build()
 
         // when
@@ -118,7 +121,7 @@ class DocumentSpec : RestSpec() {
     }
 
     @Test
-    @DisplayName("Should return not found when get existing document that belongs to another user")
+    @DisplayName("Should return 404 when get existing document that belongs to another user")
     @Sql(scripts = ["classpath:sql/DocumentSpec/setup.sql"], executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
     fun shouldReturn404whenGetDocumentAnotherUser() {
         // given
@@ -154,7 +157,7 @@ class DocumentSpec : RestSpec() {
     }
 
     @Test
-    @DisplayName("Should return error when upload file for document that does not belong to current customer")
+    @DisplayName("Should return 404 when upload file for document that does not belong to current customer")
     @Sql(scripts = ["classpath:sql/DocumentSpec/setup.sql"], executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
     fun shouldReturnErrorWhenUploadFileToNonExistingDocument() {
         // given
@@ -170,6 +173,24 @@ class DocumentSpec : RestSpec() {
 
         // then
         response.then().statusCode(HttpStatus.NOT_FOUND.value())
+    }
+
+
+    @Test
+    @DisplayName("Should return error 400 when sending empty attributes in document request")
+    fun shouldReturnError400WhenSendingEmptyAttributesInDocumentRequest() {
+        // given
+        val requestBodyEmpty = DocumentRequest().apply {
+            name = ""
+            description = ""
+        }
+        val requestSpec = prepareRequestSpecWithLogin().setBody(requestBodyEmpty).build()
+
+        // when
+        val response = given(requestSpec).post(endpoint)
+
+        // then
+        response.then().statusCode(HttpStatus.BAD_REQUEST.value())
     }
 
     fun getDocumentId(docName: String): Long? {

--- a/server/src/main/kotlin/org/hkurh/doky/documents/api/DocumentController.kt
+++ b/server/src/main/kotlin/org/hkurh/doky/documents/api/DocumentController.kt
@@ -1,5 +1,6 @@
 package org.hkurh.doky.documents.api
 
+import jakarta.validation.Valid
 import org.hkurh.doky.documents.DocumentFacade
 import org.hkurh.doky.security.DokyAuthority
 import org.slf4j.LoggerFactory
@@ -47,7 +48,7 @@ class DocumentController(private val documentFacade: DocumentFacade) : DocumentA
     }
 
     @PostMapping
-    override fun create(@RequestBody document: DocumentRequest): ResponseEntity<*> {
+    override fun create(@RequestBody @Valid document: DocumentRequest): ResponseEntity<*> {
         val createdDocument = documentFacade.createDocument(document.name, document.description)
         val resourceLocation = ServletUriComponentsBuilder.fromCurrentRequest()
             .path("/{id}").build(createdDocument!!.id)
@@ -55,7 +56,7 @@ class DocumentController(private val documentFacade: DocumentFacade) : DocumentA
     }
 
     @PutMapping("/{id}")
-    override fun update(@PathVariable id: String, @RequestBody document: DocumentRequest): ResponseEntity<*>? {
+    override fun update(@PathVariable id: String, @RequestBody @Valid document: DocumentRequest): ResponseEntity<*>? {
         documentFacade.update(id, document)
         return ResponseEntity.ok<Any>(null)
     }

--- a/server/src/main/kotlin/org/hkurh/doky/documents/api/DocumentRequest.kt
+++ b/server/src/main/kotlin/org/hkurh/doky/documents/api/DocumentRequest.kt
@@ -1,9 +1,19 @@
 package org.hkurh.doky.documents.api
 
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.NotNull
+
 /**
  * Represents a document request.
  *
  * @property name The name of the document.
  * @property description The description of the document.
  */
-class DocumentRequest(var name: String, var description: String)
+class DocumentRequest {
+    @NotNull
+    @NotBlank
+    @NotEmpty
+    var name: String = ""
+    var description: String = ""
+}

--- a/server/src/main/kotlin/org/hkurh/doky/documents/api/DocumentRequest.kt
+++ b/server/src/main/kotlin/org/hkurh/doky/documents/api/DocumentRequest.kt
@@ -1,8 +1,6 @@
 package org.hkurh.doky.documents.api
 
 import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.NotEmpty
-import jakarta.validation.constraints.NotNull
 
 /**
  * Represents a document request.
@@ -11,9 +9,7 @@ import jakarta.validation.constraints.NotNull
  * @property description The description of the document.
  */
 class DocumentRequest {
-    @NotNull
-    @NotBlank
-    @NotEmpty
+    @NotBlank(message = "Document Name can not be blank and should contain at least one non space character")
     var name: String = ""
     var description: String = ""
 }

--- a/server/src/main/kotlin/org/hkurh/doky/documents/db/DocumentEntity.kt
+++ b/server/src/main/kotlin/org/hkurh/doky/documents/db/DocumentEntity.kt
@@ -46,7 +46,7 @@ class DocumentEntity {
     @JoinColumn(name = "modified_by")
     var modifiedBy: UserEntity? = null
 
-    @Column(name = "name")
+    @Column(name = "name", nullable = false)
     var name: String? = null
 
     @Lob

--- a/server/src/main/kotlin/org/hkurh/doky/documents/impl/DefaultDocumentService.kt
+++ b/server/src/main/kotlin/org/hkurh/doky/documents/impl/DefaultDocumentService.kt
@@ -20,8 +20,9 @@ class DefaultDocumentService(
         document.description = description
         val currentUser = userService.getCurrentUser()
         document.creator = currentUser
-        LOG.debug("Created new Document ${document.id} by User ${currentUser.id}")
-        return documentEntityRepository.save(document)
+        val savedDocument = documentEntityRepository.save(document)
+        LOG.debug("Created new Document [${savedDocument.id}] by User [${currentUser.id}]")
+        return savedDocument
     }
 
     override fun find(id: String): DocumentEntity? {

--- a/server/src/main/kotlin/org/hkurh/doky/users/impl/DefaultUserService.kt
+++ b/server/src/main/kotlin/org/hkurh/doky/users/impl/DefaultUserService.kt
@@ -38,8 +38,7 @@ class DefaultUserService(
     override fun getCurrentUser(): UserEntity {
         val userEntity =
             (SecurityContextHolder.getContext().authentication.principal as DokyUserDetails).getUserEntity()
-        LOG.debug("Get current user ${userEntity!!.id}")
-        return userEntity
+        return userEntity!!
     }
 
     override fun updateUser(user: UserEntity) {

--- a/server/src/main/resources/db/migration/V15_0__make_document_name_mandatory.sql
+++ b/server/src/main/resources/db/migration/V15_0__make_document_name_mandatory.sql
@@ -1,0 +1,4 @@
+UPDATE document AS d SET d.name = CONCAT('Document ', d.id) WHERE d.name IS NULL OR d.name = '';
+
+ALTER TABLE document
+    MODIFY name VARCHAR(255) NOT NULL;

--- a/server/src/main/resources/db/migration/V15_1__add_not_empty_checks.sql
+++ b/server/src/main/resources/db/migration/V15_1__add_not_empty_checks.sql
@@ -1,0 +1,5 @@
+ALTER TABLE user ADD CONSTRAINT uid_chk_nonempty CHECK (uid <> '');
+
+ALTER TABLE reset_password_token ADD CONSTRAINT token_chk_nonempty CHECK (token <> '');
+
+ALTER TABLE document ADD CONSTRAINT name_chk_nonempty CHECK (name <> '');

--- a/server/src/test/kotlin/org/hkurh/doky/documents/DefaultDocumentFacadeTest.kt
+++ b/server/src/test/kotlin/org/hkurh/doky/documents/DefaultDocumentFacadeTest.kt
@@ -40,7 +40,10 @@ class DefaultDocumentFacadeTest : DokyUnitTest {
             name = "Test"
             description = "Description"
         }
-        val updatedDocument = DocumentRequest("Another Name", "Description for Document")
+        val updatedDocument = DocumentRequest().apply {
+            name = "Another Name"
+            description = "Description for Document"
+        }
         whenever(documentService.find(originId)).thenReturn(originDocument)
 
         // when
@@ -66,7 +69,10 @@ class DefaultDocumentFacadeTest : DokyUnitTest {
     fun shouldThrowException_whenUpdateNonExistingDocument() {
         // given
         val originId = "1"
-        val updatedDocument = DocumentRequest("Another Name", "Description for Document")
+        val updatedDocument = DocumentRequest().apply {
+            name = "Another Name"
+            description = "Description for Document"
+        }
         whenever(documentService.find(originId)).thenReturn(null)
 
         // when - then


### PR DESCRIPTION
**Make document name mandatory and add non-empty checks**

This commit introduces a change to make the document name field mandatory in the database and in the `DocumentEntity` class. It also includes new not-empty check constraints for `uid` in `user` table, the `token` in `reset_password_token` table, and the `name` in the `document` table.


**Add validation for `DocumentRequest` and improve log messages**

The `DocumentRequest` fields have been modified to include validation annotations preventing empty or null values, enhancing data integrity. Changes have also been made to improve the precision of logged messages, including the addition of a post-save log in `DefaultDocumentService.kt`. Lastly, the code constructs a `DocumentRequest` using `apply` method for more readability.