### PR TITLE
MAIN-T-121 Default search for Documents

### DIFF
--- a/server/.run/DokyApplication DEV.run.xml
+++ b/server/.run/DokyApplication DEV.run.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="DokyApplication DEV" type="SpringBootApplicationConfigurationType"
+                   factoryName="Spring Boot">
+        <option name="ACTIVE_PROFILES" value="dev"/>
+        <option name="FRAME_DEACTIVATION_UPDATE_POLICY" value="UpdateClassesAndResources"/>
+        <module name="doky.server.main"/>
+        <option name="SPRING_BOOT_MAIN_CLASS" value="org.hkurh.doky.DokyApplication"/>
+        <extension name="net.ashald.envfile">
+            <option name="IS_ENABLED" value="true"/>
+            <option name="IS_SUBST" value="false"/>
+            <option name="IS_PATH_MACRO_SUPPORTED" value="false"/>
+            <option name="IS_IGNORE_MISSING_FILES" value="false"/>
+            <option name="IS_ENABLE_EXPERIMENTAL_INTEGRATIONS" value="false"/>
+            <ENTRIES>
+                <ENTRY IS_ENABLED="true" PARSER="runconfig" IS_EXECUTABLE="false"/>
+                <ENTRY IS_ENABLED="true" PARSER="env" IS_EXECUTABLE="false" PATH="doky-dev.env"/>
+            </ENTRIES>
+        </extension>
+        <method v="2">
+            <option name="Make" enabled="true"/>
+        </method>
+    </configuration>
+</component>

--- a/server/.run/DokyApplication.run.xml
+++ b/server/.run/DokyApplication.run.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="DokyApplication" type="SpringBootApplicationConfigurationType"
+                   factoryName="Spring Boot" nameIsGenerated="true">
+        <option name="ACTIVE_PROFILES" value="local"/>
+        <option name="FRAME_DEACTIVATION_UPDATE_POLICY" value="UpdateClassesAndResources"/>
+        <module name="doky.server.main"/>
+        <option name="SPRING_BOOT_MAIN_CLASS" value="org.hkurh.doky.DokyApplication"/>
+        <extension name="net.ashald.envfile">
+            <option name="IS_ENABLED" value="true"/>
+            <option name="IS_SUBST" value="false"/>
+            <option name="IS_PATH_MACRO_SUPPORTED" value="false"/>
+            <option name="IS_IGNORE_MISSING_FILES" value="false"/>
+            <option name="IS_ENABLE_EXPERIMENTAL_INTEGRATIONS" value="false"/>
+            <ENTRIES>
+                <ENTRY IS_ENABLED="true" PARSER="runconfig" IS_EXECUTABLE="false"/>
+                <ENTRY IS_ENABLED="true" PARSER="env" IS_EXECUTABLE="false" PATH="doky-local.env"/>
+            </ENTRIES>
+        </extension>
+        <method v="2">
+            <option name="Make" enabled="true"/>
+        </method>
+    </configuration>
+</component>

--- a/server/.run/server [apiTest].run.xml
+++ b/server/.run/server [apiTest].run.xml
@@ -33,4 +33,38 @@
         <RunAsTest>false</RunAsTest>
         <method v="2"/>
     </configuration>
+    <configuration default="false" name="server [apiTest]" type="GradleRunConfiguration" factoryName="Gradle">
+        <ExternalSystemSettings>
+            <option name="executionName"/>
+            <option name="externalProjectPath" value="$PROJECT_DIR$/server"/>
+            <option name="externalSystemIdString" value="GRADLE"/>
+            <option name="scriptParameters" value="-PrunApiTests=true"/>
+            <option name="taskDescriptions">
+                <list/>
+            </option>
+            <option name="taskNames">
+                <list>
+                    <option value="apiTest"/>
+                </list>
+            </option>
+            <option name="vmOptions"/>
+        </ExternalSystemSettings>
+        <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+        <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+        <EXTENSION ID="com.intellij.execution.ExternalSystemRunConfigurationJavaExtension">
+            <extension name="net.ashald.envfile">
+                <option name="IS_ENABLED" value="false"/>
+                <option name="IS_SUBST" value="false"/>
+                <option name="IS_PATH_MACRO_SUPPORTED" value="false"/>
+                <option name="IS_IGNORE_MISSING_FILES" value="false"/>
+                <option name="IS_ENABLE_EXPERIMENTAL_INTEGRATIONS" value="false"/>
+                <ENTRIES>
+                    <ENTRY IS_ENABLED="true" PARSER="runconfig" IS_EXECUTABLE="false"/>
+                </ENTRIES>
+            </extension>
+        </EXTENSION>
+        <DebugAllEnabled>false</DebugAllEnabled>
+        <RunAsTest>false</RunAsTest>
+        <method v="2"/>
+    </configuration>
 </component>

--- a/server/.run/server [integrationTest].run.xml
+++ b/server/.run/server [integrationTest].run.xml
@@ -33,4 +33,38 @@
         <RunAsTest>false</RunAsTest>
         <method v="2"/>
     </configuration>
+    <configuration default="false" name="server [integrationTest]" type="GradleRunConfiguration" factoryName="Gradle">
+        <ExternalSystemSettings>
+            <option name="executionName"/>
+            <option name="externalProjectPath" value="$PROJECT_DIR$/server"/>
+            <option name="externalSystemIdString" value="GRADLE"/>
+            <option name="scriptParameters" value="-PrunIntegrationTests=true"/>
+            <option name="taskDescriptions">
+                <list/>
+            </option>
+            <option name="taskNames">
+                <list>
+                    <option value="integrationTest"/>
+                </list>
+            </option>
+            <option name="vmOptions"/>
+        </ExternalSystemSettings>
+        <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+        <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+        <EXTENSION ID="com.intellij.execution.ExternalSystemRunConfigurationJavaExtension">
+            <extension name="net.ashald.envfile">
+                <option name="IS_ENABLED" value="false"/>
+                <option name="IS_SUBST" value="false"/>
+                <option name="IS_PATH_MACRO_SUPPORTED" value="false"/>
+                <option name="IS_IGNORE_MISSING_FILES" value="false"/>
+                <option name="IS_ENABLE_EXPERIMENTAL_INTEGRATIONS" value="false"/>
+                <ENTRIES>
+                    <ENTRY IS_ENABLED="true" PARSER="runconfig" IS_EXECUTABLE="false"/>
+                </ENTRIES>
+            </extension>
+        </EXTENSION>
+        <DebugAllEnabled>false</DebugAllEnabled>
+        <RunAsTest>false</RunAsTest>
+        <method v="2"/>
+    </configuration>
 </component>

--- a/server/.run/server [test].run.xml
+++ b/server/.run/server [test].run.xml
@@ -1,24 +1,70 @@
 <component name="ProjectRunConfigurationManager">
-    <configuration default="false" name="server [test]" type="GradleRunConfiguration" factoryName="Gradle">
-        <ExternalSystemSettings>
-            <option name="executionName"/>
-            <option name="externalProjectPath" value="$PROJECT_DIR$/server"/>
-            <option name="externalSystemIdString" value="GRADLE"/>
-            <option name="scriptParameters" value=""/>
-            <option name="taskDescriptions">
-                <list/>
-            </option>
-            <option name="taskNames">
-                <list>
-                    <option value="test"/>
-                </list>
-            </option>
-            <option name="vmOptions"/>
-        </ExternalSystemSettings>
-        <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
-        <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
-        <DebugAllEnabled>false</DebugAllEnabled>
-        <RunAsTest>false</RunAsTest>
-        <method v="2"/>
-    </configuration>
+  <configuration default="false" name="server [test]" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName"/>
+      <option name="externalProjectPath" value="$PROJECT_DIR$/server"/>
+      <option name="externalSystemIdString" value="GRADLE"/>
+      <option name="scriptParameters" value=""/>
+      <option name="taskDescriptions">
+        <list/>
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="test"/>
+        </list>
+      </option>
+      <option name="vmOptions"/>
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <EXTENSION ID="com.intellij.execution.ExternalSystemRunConfigurationJavaExtension">
+      <extension name="net.ashald.envfile">
+        <option name="IS_ENABLED" value="false"/>
+        <option name="IS_SUBST" value="false"/>
+        <option name="IS_PATH_MACRO_SUPPORTED" value="false"/>
+        <option name="IS_IGNORE_MISSING_FILES" value="false"/>
+        <option name="IS_ENABLE_EXPERIMENTAL_INTEGRATIONS" value="false"/>
+        <ENTRIES>
+          <ENTRY IS_ENABLED="true" PARSER="runconfig" IS_EXECUTABLE="false"/>
+        </ENTRIES>
+      </extension>
+    </EXTENSION>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2"/>
+  </configuration>
+  <configuration default="false" name="server [test]" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName"/>
+      <option name="externalProjectPath" value="$PROJECT_DIR$/server"/>
+      <option name="externalSystemIdString" value="GRADLE"/>
+      <option name="scriptParameters" value=""/>
+      <option name="taskDescriptions">
+        <list/>
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="test"/>
+        </list>
+      </option>
+      <option name="vmOptions"/>
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <EXTENSION ID="com.intellij.execution.ExternalSystemRunConfigurationJavaExtension">
+      <extension name="net.ashald.envfile">
+        <option name="IS_ENABLED" value="false"/>
+        <option name="IS_SUBST" value="false"/>
+        <option name="IS_PATH_MACRO_SUPPORTED" value="false"/>
+        <option name="IS_IGNORE_MISSING_FILES" value="false"/>
+        <option name="IS_ENABLE_EXPERIMENTAL_INTEGRATIONS" value="false"/>
+        <ENTRIES>
+          <ENTRY IS_ENABLED="true" PARSER="runconfig" IS_EXECUTABLE="false"/>
+        </ENTRIES>
+      </extension>
+    </EXTENSION>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2"/>
+  </configuration>
 </component>

--- a/server/src/apiTest/kotlin/org/hkurh/doky/DocumentSpec.kt
+++ b/server/src/apiTest/kotlin/org/hkurh/doky/DocumentSpec.kt
@@ -3,17 +3,12 @@ package org.hkurh.doky
 import io.restassured.RestAssured.given
 import org.hamcrest.CoreMatchers.notNullValue
 import org.hkurh.doky.documents.api.DocumentRequest
-import org.hkurh.doky.documents.db.DocumentEntityRepository
-import org.hkurh.doky.users.db.UserEntityRepository
 import org.junit.Rule
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.rules.TemporaryFolder
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.test.context.jdbc.Sql
@@ -33,28 +28,20 @@ class DocumentSpec : RestSpec() {
     val documentFileNameProperty = "fileName"
     val existedDocumentNameFirst = "Test_1"
     val existedDocumentFileNameFirst = "test.txt"
-    val existedDocumentNameSecond = "Test_2"
     val existedDocumentNameThird = "Test_3"
-    val existedDocumentNameFour = "Test_4"
     val newDocumentName = "Apples"
     val newDocumentDescription = "Do you like apples?"
     val uploadFileName = "test_1.txt"
 
     @Value("\${doky.filestorage.path}")
-    val fileStoragePath: String? = null
+    lateinit var fileStoragePath: String
 
     @Rule
     var temporaryFolder = TemporaryFolder()
 
-    @Autowired
-    lateinit var documentEntityRepository: DocumentEntityRepository
-
-    @Autowired
-    lateinit var userEntityRepository: UserEntityRepository
-
     @AfterEach
     fun tearDown() {
-        fileStoragePath?.let {
+        fileStoragePath.let {
             FileSystemUtils.deleteRecursively(Paths.get(it))
         }
     }
@@ -98,26 +85,6 @@ class DocumentSpec : RestSpec() {
         assertEquals(docId, id)
         val fileName: String = response.path(documentFileNameProperty)
         assertEquals(existedDocumentFileNameFirst, fileName)
-    }
-
-    @Test
-    @DisplayName("Should get all existing documents for user")
-    @Sql(scripts = ["classpath:sql/DocumentSpec/setup.sql"], executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
-    fun shouldGetAllExistingDocumentsForUser() {
-        // given
-        val requestSpec = prepareRequestSpecWithLogin().build()
-
-        // when:
-        val response = given(requestSpec).get(endpoint)
-
-        // then
-        response.then().statusCode(HttpStatus.OK.value())
-        val documents: List<Map<String, String>> = response.path(".")
-
-        assertNotNull(documents.find { d -> (existedDocumentNameFirst == d[documentNameProperty]) })
-        assertNotNull(documents.find { d -> (existedDocumentNameSecond == d[documentNameProperty]) })
-        assertNull(documents.find { d -> (existedDocumentNameThird == d[documentNameProperty]) })
-        assertNull(documents.find { d -> (existedDocumentNameFour == d[documentNameProperty]) })
     }
 
     @Test

--- a/server/src/main/kotlin/org/hkurh/doky/documents/DocumentFacade.kt
+++ b/server/src/main/kotlin/org/hkurh/doky/documents/DocumentFacade.kt
@@ -38,13 +38,6 @@ interface DocumentFacade {
     fun findDocument(id: String): DocumentResponse?
 
     /**
-     * Retrieves a list of all documents.
-     *
-     * @return A list of [DocumentResponse] objects representing the retrieved documents. The list may contain null values if the document retrieval failed.
-     */
-    fun findAllDocuments(): List<DocumentResponse?>
-
-    /**
      * Saves a file and attach it to document with the given ID.
      *
      * @param file The file to be saved.

--- a/server/src/main/kotlin/org/hkurh/doky/documents/DocumentService.kt
+++ b/server/src/main/kotlin/org/hkurh/doky/documents/DocumentService.kt
@@ -24,13 +24,6 @@ interface DocumentService {
     fun find(id: String): DocumentEntity?
 
     /**
-     * Finds all documents.
-     *
-     * @return A list of [DocumentEntity] objects representing the found documents.
-     */
-    fun find(): List<DocumentEntity>
-
-    /**
      * Saves the given document.
      *
      * @param document The [DocumentEntity] object to be saved.

--- a/server/src/main/kotlin/org/hkurh/doky/documents/api/DocumentApi.kt
+++ b/server/src/main/kotlin/org/hkurh/doky/documents/api/DocumentApi.kt
@@ -2,7 +2,6 @@ package org.hkurh.doky.documents.api
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.headers.Header
-import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -42,11 +41,11 @@ interface DocumentApi {
     @ApiResponses(ApiResponse(responseCode = "200", description = "Document is updated"))
     fun update(@PathVariable id: String, document: DocumentRequest): ResponseEntity<*>?
 
-    @ApiResponses(
-            ApiResponse(responseCode = "200", description = "List if documents is retrieved successfully",
-                    content = [Content(array = ArraySchema(schema = Schema(implementation = DocumentResponse::class)))]))
-    @Operation(summary = "Get all documents that was created by current customer")
-    fun getAll(): ResponseEntity<*>?
+//    @ApiResponses(
+//            ApiResponse(responseCode = "200", description = "List if documents is retrieved successfully",
+//                    content = [Content(array = ArraySchema(schema = Schema(implementation = DocumentResponse::class)))]))
+//    @Operation(summary = "Get all documents that was created by current customer")
+//    fun getAll(): ResponseEntity<*>?
 
     @Operation(summary = "Get metadata for document")
     @ApiResponses(

--- a/server/src/main/kotlin/org/hkurh/doky/documents/api/DocumentController.kt
+++ b/server/src/main/kotlin/org/hkurh/doky/documents/api/DocumentController.kt
@@ -61,12 +61,6 @@ class DocumentController(private val documentFacade: DocumentFacade) : DocumentA
         return ResponseEntity.ok<Any>(null)
     }
 
-    @GetMapping
-    override fun getAll(): ResponseEntity<*> {
-        val documents = documentFacade.findAllDocuments()
-        return ResponseEntity.ok(documents)
-    }
-
     @GetMapping("/{id}")
     override fun get(@PathVariable id: String): ResponseEntity<*> {
         val document = documentFacade.findDocument(id)

--- a/server/src/main/kotlin/org/hkurh/doky/documents/db/DocumentEntityRepository.kt
+++ b/server/src/main/kotlin/org/hkurh/doky/documents/db/DocumentEntityRepository.kt
@@ -11,9 +11,6 @@ import java.util.*
  */
 interface DocumentEntityRepository : CrudRepository<DocumentEntity?, Long?>, JpaSpecificationExecutor<DocumentEntity?> {
 
-    @Query("select d from DocumentEntity d where d.creator.id = ?1")
-    fun findByCreatorId(documentId: Long): List<DocumentEntity>
-
     @Query("select d from DocumentEntity d where d.id = ?1 and d.creator.id = ?2")
     fun findByIdAndCreatorId(documentId: Long, creatorId: Long): DocumentEntity?
 

--- a/server/src/main/kotlin/org/hkurh/doky/documents/impl/DefaultDocumentFacade.kt
+++ b/server/src/main/kotlin/org/hkurh/doky/documents/impl/DefaultDocumentFacade.kt
@@ -42,10 +42,6 @@ class DefaultDocumentFacade(
         return documentService.find(id)?.toDto()
     }
 
-    override fun findAllDocuments(): List<DocumentResponse?> {
-        return documentService.find().map { it.toDto() }
-    }
-
     @Transactional(propagation = Propagation.REQUIRED)
     override fun saveFile(file: MultipartFile, id: String) {
         val document = documentService.find(id)

--- a/server/src/main/kotlin/org/hkurh/doky/documents/impl/DefaultDocumentService.kt
+++ b/server/src/main/kotlin/org/hkurh/doky/documents/impl/DefaultDocumentService.kt
@@ -11,8 +11,7 @@ import org.springframework.stereotype.Service
 class DefaultDocumentService(
     private val documentEntityRepository: DocumentEntityRepository,
     private val userService: UserService
-) :
-    DocumentService {
+) : DocumentService {
 
     override fun create(name: String, description: String?): DocumentEntity {
         val document = DocumentEntity()
@@ -29,11 +28,6 @@ class DefaultDocumentService(
         val documentId = id.toLong()
         val currentUser = userService.getCurrentUser()
         return documentEntityRepository.findByIdAndCreatorId(documentId, currentUser.id)
-    }
-
-    override fun find(): List<DocumentEntity> {
-        val currentUser = userService.getCurrentUser()
-        return documentEntityRepository.findByCreatorId(currentUser.id)
     }
 
     override fun save(document: DocumentEntity) {

--- a/server/src/main/kotlin/org/hkurh/doky/search/api/DocumentSearchApi.kt
+++ b/server/src/main/kotlin/org/hkurh/doky/search/api/DocumentSearchApi.kt
@@ -2,7 +2,13 @@ package org.hkurh.doky.search.api
 
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
 
 @Tag(name = "Documents")
 @SecurityRequirement(name = "Bearer Token")
-interface DocumentSearchApi
+interface DocumentSearchApi {
+
+    @GetMapping
+    fun search(q: String? = "*"): ResponseEntity<*>
+}

--- a/server/src/main/kotlin/org/hkurh/doky/search/api/DocumentSearchController.kt
+++ b/server/src/main/kotlin/org/hkurh/doky/search/api/DocumentSearchController.kt
@@ -21,8 +21,9 @@ class DocumentSearchController(
     private val documentSearchFacade: DocumentSearchFacade
 ) : DocumentSearchApi {
 
-    @GetMapping("/search")
-    fun search(@RequestParam(name = "q") query: String): ResponseEntity<*> {
+    @GetMapping
+    override fun search(@RequestParam q: String?): ResponseEntity<*> {
+        val query = q?.ifEmpty { "*" } ?: "*"
         val documents = documentSearchFacade.search(query)
         return ResponseEntity.ok(documents)
     }


### PR DESCRIPTION
Update logic for document retrieval and search pattern

Removed logic that retrieves all documents for a user in `DocumentService` and `DocumentFacade`. Simplified search pattern in `SearchSpec` and `DocumentSearchController`. Adjusted the corresponding API interfaces and modified various configuration files.