### PR TITLE
DOKY-153 Add prefix for API

### DIFF
--- a/server/src/apiTest/kotlin/org/hkurh/doky/DocumentSpec.kt
+++ b/server/src/apiTest/kotlin/org/hkurh/doky/DocumentSpec.kt
@@ -20,7 +20,7 @@ import java.sql.Types
 @Sql(scripts = ["classpath:sql/DocumentSpec/cleanup.sql"], executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
 @DisplayName("Documents API test")
 class DocumentSpec : RestSpec() {
-    val endpoint = "/documents"
+    val endpoint = "$restPrefix/documents"
     val endpointSingle = "$endpoint/{id}"
     val endpointUpload = "$endpointSingle/upload"
     val documentIdProperty = "id"

--- a/server/src/apiTest/kotlin/org/hkurh/doky/LoginSpec.kt
+++ b/server/src/apiTest/kotlin/org/hkurh/doky/LoginSpec.kt
@@ -12,7 +12,7 @@ import org.springframework.http.HttpStatus
 
 @DisplayName("Login API test")
 class LoginSpec : RestSpec() {
-    val endpoint = "/login"
+    val endpoint = "$restPrefix/login"
     val incorrectUserUid = "test_1234@example.com"
     val incorrectUserPassword = "pass-12345"
 

--- a/server/src/apiTest/kotlin/org/hkurh/doky/PasswordSpec.kt
+++ b/server/src/apiTest/kotlin/org/hkurh/doky/PasswordSpec.kt
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus
 @DisplayName("Password API test")
 class PasswordSpec : RestSpec() {
 
-    private val endpoint = "/password"
+    private val endpoint = "$restPrefix/password"
     private val resetEndpoint = "$endpoint/reset"
     private val nonExistUserEmail = "test-no-registered@test.com"
 

--- a/server/src/apiTest/kotlin/org/hkurh/doky/RegistrationSpec.kt
+++ b/server/src/apiTest/kotlin/org/hkurh/doky/RegistrationSpec.kt
@@ -12,9 +12,9 @@ import org.springframework.test.context.jdbc.Sql
 
 @DisplayName("Registration API test")
 class RegistrationSpec : RestSpec() {
+    val endpoint = "$restPrefix/register"
     val newUserUid = "new_user_test@example.com"
     val newUserPassword = "Qwert!2345"
-    val endpoint = "/register"
 
     @Test
     @DisplayName("Should register user when it does not exist")

--- a/server/src/apiTest/kotlin/org/hkurh/doky/RestSpec.kt
+++ b/server/src/apiTest/kotlin/org/hkurh/doky/RestSpec.kt
@@ -26,7 +26,8 @@ import org.springframework.test.context.jdbc.SqlMergeMode
 @Sql(scripts = ["classpath:sql/cleanup_base_test_data.sql"], executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
 class RestSpec {
     protected val baseHost = "http://localhost"
-    protected val loginEndpoint = "/login"
+    protected val restPrefix = "/api"
+    protected val loginEndpoint = "$restPrefix/login"
     protected val authorizationHeader = "Authorization"
     protected val locationHeader = "Location"
     protected val contentTypeHeader = "Content-Type"

--- a/server/src/main/kotlin/org/hkurh/doky/DokyController.kt
+++ b/server/src/main/kotlin/org/hkurh/doky/DokyController.kt
@@ -1,16 +1,12 @@
 package org.hkurh.doky
 
-import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
-@RestController
+@RestController()
+@RequestMapping("/api")
 class DokyController {
-
-    @GetMapping("/")
-    fun root(): ResponseEntity<*> {
-        return ResponseEntity.ok().body("OK")
-    }
 
     @GetMapping("/version")
     fun version(): VersionResponse {

--- a/server/src/main/kotlin/org/hkurh/doky/authorization/AuthorizationUserController.kt
+++ b/server/src/main/kotlin/org/hkurh/doky/authorization/AuthorizationUserController.kt
@@ -6,6 +6,7 @@ import org.hkurh.doky.users.UserFacade
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder
 
@@ -15,6 +16,7 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder
  * @property userFacade The facade for user-related operations.
  */
 @RestController
+@RequestMapping("/api")
 class AuthorizationUserController(private val userFacade: UserFacade) : AuthorizationUserApi {
     @PostMapping("/login")
     override fun login(@Valid @RequestBody authenticationRequest: AuthenticationRequest): ResponseEntity<AuthenticationResponse> {

--- a/server/src/main/kotlin/org/hkurh/doky/documents/api/DocumentController.kt
+++ b/server/src/main/kotlin/org/hkurh/doky/documents/api/DocumentController.kt
@@ -17,7 +17,7 @@ import java.net.MalformedURLException
  * Controller class for handling document-related operations.
  */
 @RestController
-@RequestMapping("/documents")
+@RequestMapping("/api/documents")
 @PreAuthorize("hasRole('ROLE_USER')")
 class DocumentController(private val documentFacade: DocumentFacade) : DocumentApi {
 

--- a/server/src/main/kotlin/org/hkurh/doky/password/api/PasswordController.kt
+++ b/server/src/main/kotlin/org/hkurh/doky/password/api/PasswordController.kt
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController
  * @param passwordFacade The [PasswordFacade] instance used to delegate the password operations.
  */
 @RestController
-@RequestMapping("/password")
+@RequestMapping("/api/password")
 class PasswordController(
     val passwordFacade: PasswordFacade
 ) : PasswordApi {

--- a/server/src/main/kotlin/org/hkurh/doky/security/JwtAuthorizationFilter.kt
+++ b/server/src/main/kotlin/org/hkurh/doky/security/JwtAuthorizationFilter.kt
@@ -31,7 +31,7 @@ import java.io.IOException
 @Component
 class JwtAuthorizationFilter(private val userService: UserService) : OncePerRequestFilter() {
     private val authorizationHeader = "Authorization"
-    private val anonymousEndpoints = setOf("/register", "/login", "/password/reset")
+    private val anonymousEndpoints = setOf("/api/register", "/api/login", "/api/password/reset")
 
     @Throws(ServletException::class, IOException::class)
     override fun doFilterInternal(

--- a/server/src/main/kotlin/org/hkurh/doky/users/api/UserController.kt
+++ b/server/src/main/kotlin/org/hkurh/doky/users/api/UserController.kt
@@ -7,6 +7,7 @@ import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 /**
@@ -15,15 +16,16 @@ import org.springframework.web.bind.annotation.RestController
  * @param userFacade The [UserFacade] instance for handling user-related business logic.
  */
 @RestController
+@RequestMapping("/api/users")
 @PreAuthorize("hasRole('ROLE_USER')")
 class UserController(private val userFacade: UserFacade) : UserApi {
 
-    @GetMapping("/users/current")
+    @GetMapping("/current")
     override fun getUser(): UserDto {
         return userFacade.getCurrentUser()
     }
 
-    @PutMapping("/users/current")
+    @PutMapping("/current")
     override fun updateUser(@Validated @RequestBody userDto: UserDto): ResponseEntity<*> {
         userFacade.updateCurrentUser(userDto)
         return ResponseEntity.noContent().build<Any>()

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -41,3 +41,5 @@ spring.security.user.name=user
 spring.security.user.password=<CHANGE_ME>
 # password
 doky.password.reset.token.duration=10
+# actuator
+management.endpoints.web.base-path=/api/actuator


### PR DESCRIPTION
Refactor API routes to use `/api` prefix

API endpoints across the application have been refactored to include an `/api` prefix. Tests have been updated to reflect this change. This makes the application follow standard RESTful API conventions better and makes differentiating between frontend and backend requests clearer.