### PR TITLE
DOKY-169 Could not to update username

### DIFF
--- a/server/src/apiTest/kotlin/org/hkurh/doky/PasswordSpec.kt
+++ b/server/src/apiTest/kotlin/org/hkurh/doky/PasswordSpec.kt
@@ -46,5 +46,4 @@ class PasswordSpec : RestSpec() {
         // then
         response.then().statusCode(HttpStatus.NO_CONTENT.value())
     }
-
 }

--- a/server/src/apiTest/kotlin/org/hkurh/doky/UserSpec.kt
+++ b/server/src/apiTest/kotlin/org/hkurh/doky/UserSpec.kt
@@ -1,0 +1,46 @@
+package org.hkurh.doky
+
+import io.restassured.RestAssured.given
+import org.hamcrest.CoreMatchers.notNullValue
+import org.hkurh.doky.users.api.UpdateUserRequest
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+
+@DisplayName("User API test")
+class UserSpec : RestSpec() {
+
+    private val endpoint = "$restPrefix/users/current"
+
+    @Test
+    @DisplayName("Should update username when it is provided")
+    fun shouldUpdateUserName_whenUserNameProvided() {
+        // given
+        val requestBody = UpdateUserRequest().apply {
+            name = "New Name"
+        }
+        val requestSpec = prepareRequestSpecWithLogin().setBody(requestBody).build()
+
+        // when
+        val response = given(requestSpec).put(endpoint)
+
+        // then
+        response.then().statusCode(HttpStatus.OK.value())
+    }
+
+    @Test
+    @DisplayName("Should return error when update user data with empty username")
+    fun shouldReturnError_whenUpdateUserDataWithEmptyUsername() {
+        // given
+        val requestBody = UpdateUserRequest()
+        val requestSpec = prepareRequestSpecWithLogin().setBody(requestBody).build()
+
+        // when
+        val response = given(requestSpec).put(endpoint)
+
+        // then
+        response.then().statusCode(HttpStatus.BAD_REQUEST.value())
+            .body("error", notNullValue())
+            .body("error.message", notNullValue())
+    }
+}

--- a/server/src/main/kotlin/org/hkurh/doky/users/UserFacade.kt
+++ b/server/src/main/kotlin/org/hkurh/doky/users/UserFacade.kt
@@ -1,5 +1,6 @@
 package org.hkurh.doky.users
 
+import org.hkurh.doky.users.api.UpdateUserRequest
 import org.hkurh.doky.users.api.UserDto
 
 /**
@@ -33,7 +34,7 @@ interface UserFacade {
     /**
      * Updates the information of the current user that is authenticated for request.
      *
-     * @param userDto The updated user information as a [UserDto] object.
+     * @param updateUserRequest The updated user information as a [UpdateUserRequest] object.
      */
-    fun updateCurrentUser(userDto: UserDto)
+    fun updateCurrentUser(updateUserRequest: UpdateUserRequest)
 }

--- a/server/src/main/kotlin/org/hkurh/doky/users/api/UpdateUserRequest.kt
+++ b/server/src/main/kotlin/org/hkurh/doky/users/api/UpdateUserRequest.kt
@@ -1,0 +1,8 @@
+package org.hkurh.doky.users.api
+
+import jakarta.validation.constraints.NotBlank
+
+class UpdateUserRequest {
+    @NotBlank(message = "User name cannot be empty")
+    var name: String? = null
+}

--- a/server/src/main/kotlin/org/hkurh/doky/users/api/UserApi.kt
+++ b/server/src/main/kotlin/org/hkurh/doky/users/api/UserApi.kt
@@ -19,8 +19,11 @@ interface UserApi {
     fun getUser(): UserDto
 
     @ApiResponses(
-        ApiResponse(responseCode = "201", description = "User information is updated successfully",
-            content = [Content(schema = Schema(implementation = UserDto::class))]))
+        ApiResponse(
+            responseCode = "200", description = "User information is updated successfully",
+            content = [Content(schema = Schema(implementation = UpdateUserRequest::class))]
+        )
+    )
     @Operation(summary = "Update current user info")
-    fun updateUser(userDto: UserDto): ResponseEntity<*>?
+    fun updateUser(updateUserRequest: UpdateUserRequest): ResponseEntity<*>?
 }

--- a/server/src/main/kotlin/org/hkurh/doky/users/api/UserController.kt
+++ b/server/src/main/kotlin/org/hkurh/doky/users/api/UserController.kt
@@ -26,8 +26,8 @@ class UserController(private val userFacade: UserFacade) : UserApi {
     }
 
     @PutMapping("/current")
-    override fun updateUser(@Validated @RequestBody userDto: UserDto): ResponseEntity<*> {
-        userFacade.updateCurrentUser(userDto)
-        return ResponseEntity.noContent().build<Any>()
+    override fun updateUser(@Validated @RequestBody updateUserRequest: UpdateUserRequest): ResponseEntity<*> {
+        userFacade.updateCurrentUser(updateUserRequest)
+        return ResponseEntity.ok().build<Any>()
     }
 }

--- a/server/src/main/kotlin/org/hkurh/doky/users/impl/DefaultUserFacade.kt
+++ b/server/src/main/kotlin/org/hkurh/doky/users/impl/DefaultUserFacade.kt
@@ -6,6 +6,7 @@ import org.hkurh.doky.errorhandling.DokyRegistrationException
 import org.hkurh.doky.toDto
 import org.hkurh.doky.users.UserFacade
 import org.hkurh.doky.users.UserService
+import org.hkurh.doky.users.api.UpdateUserRequest
 import org.hkurh.doky.users.api.UserDto
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Component
@@ -34,11 +35,9 @@ class DefaultUserFacade(private val userService: UserService, private val passwo
         return userService.getCurrentUser().toDto()
     }
 
-    override fun updateCurrentUser(userDto: UserDto) {
+    override fun updateCurrentUser(updateUserRequest: UpdateUserRequest) {
         val currentUser = userService.getCurrentUser()
-        currentUser.name = userDto.name?.ifEmpty { currentUser.name } ?: userDto.name
-        currentUser.password =
-            userDto.password?.ifEmpty { currentUser.password } ?: passwordEncoder.encode(userDto.password)
+        currentUser.name = updateUserRequest.name?.ifEmpty { currentUser.name } ?: updateUserRequest.name
         userService.updateUser(currentUser)
     }
 


### PR DESCRIPTION
Replace `UserDto` with `UpdateUserRequest` in update user flow

Standardize the update user request handling by changing from `UserDto` to UpdateUserRequest in order do not validate password as it should not be sent. Adjusted endpoints, validation classes, and the facade to ensure proper handling of user update logic. Also added new `UserSpec` tests to validate the functionality.