### PR TITLE
DOKY-170 Error-free response for password restoration with non-existent email

### DIFF
--- a/server/src/apiTest/kotlin/org/hkurh/doky/PasswordSpec.kt
+++ b/server/src/apiTest/kotlin/org/hkurh/doky/PasswordSpec.kt
@@ -2,6 +2,7 @@ package org.hkurh.doky
 
 import io.restassured.RestAssured.given
 import org.hkurh.doky.password.api.ResetPasswordRequest
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
@@ -15,8 +16,8 @@ class PasswordSpec : RestSpec() {
 
 
     @Test
-    @DisplayName("Should return Not Fount if no user with provided email")
-    fun shouldReturnNotFount_whenNoUserWithProvidedEmail() {
+    @DisplayName("Should process if no user with provided email")
+    fun shouldProcess_whenNoUserWithProvidedEmail() {
         // given
         val requestBody = ResetPasswordRequest().apply {
             email = nonExistUserEmail
@@ -27,12 +28,12 @@ class PasswordSpec : RestSpec() {
         val response = given(requestSpec).post(resetEndpoint)
 
         // then
-        response.then().statusCode(HttpStatus.NOT_FOUND.value())
+        response.then().statusCode(HttpStatus.NO_CONTENT.value())
     }
 
-    //    @Ignore("Need to fix that ORM uses `user` column name without escaping (reserved on SQL Server)")
-//    @Test
-//    @DisplayName("Should process if user with provided email exists")
+    @Disabled("Need to fix that ORM uses `user` column name without escaping (reserved on SQL Server)")
+    @Test
+    @DisplayName("Should process if user with provided email exists")
     fun shouldProcess_whenUserExists() {
         // given
         val requestBody = ResetPasswordRequest().apply {

--- a/server/src/main/kotlin/org/hkurh/doky/password/api/PasswordApi.kt
+++ b/server/src/main/kotlin/org/hkurh/doky/password/api/PasswordApi.kt
@@ -15,8 +15,7 @@ interface PasswordApi {
 
     @Operation(summary = "Send a request (email) to restore password for user")
     @ApiResponses(
-        ApiResponse(responseCode = "204", description = "Reset password request is applied successfully"),
-        ApiResponse(responseCode = "404", description = "There no registered user with provided email")
+        ApiResponse(responseCode = "204", description = "Reset password request is applied successfully")
     )
     fun reset(@RequestBody resetPasswordRequest: ResetPasswordRequest): ResponseEntity<Any>
 }

--- a/server/src/test/kotlin/org/hkurh/doky/password/DefaultPasswordFacadeTest.kt
+++ b/server/src/test/kotlin/org/hkurh/doky/password/DefaultPasswordFacadeTest.kt
@@ -2,13 +2,11 @@ package org.hkurh.doky.password
 
 import org.hkurh.doky.DokyUnitTest
 import org.hkurh.doky.email.EmailService
-import org.hkurh.doky.errorhandling.DokyNotFoundException
 import org.hkurh.doky.password.impl.DefaultPasswordFacade
 import org.hkurh.doky.users.UserService
 import org.hkurh.doky.users.db.UserEntity
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -61,12 +59,12 @@ class DefaultPasswordFacadeTest : DokyUnitTest {
 
     @Test
     @DisplayName("Should throw exception when user doesn't exist")
-    fun shouldThrowException_whenUserDoesNotExist() {
+    fun shouldDoNothing_whenUserDoesNotExist() {
         // given
         whenever(userService.exists(userEmail)).thenReturn(false)
 
         // when - then
-        assertThrows<DokyNotFoundException> { passwordFacade.reset(userEmail) }
+        passwordFacade.reset(userEmail)
 
         // then
         verifyNoMoreInteractions(resetPasswordService)


### PR DESCRIPTION
Refactor password reset to handle non-existent users gracefully and avoiding the exception. The reason is to not expose information about emails that are used by registered users.