### PR TITLE
DOKY-173 Fix disabled Password API test

### DIFF
--- a/server/src/apiTest/kotlin/org/hkurh/doky/PasswordSpec.kt
+++ b/server/src/apiTest/kotlin/org/hkurh/doky/PasswordSpec.kt
@@ -2,7 +2,6 @@ package org.hkurh.doky
 
 import io.restassured.RestAssured.given
 import org.hkurh.doky.password.api.ResetPasswordRequest
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
@@ -31,7 +30,6 @@ class PasswordSpec : RestSpec() {
         response.then().statusCode(HttpStatus.NO_CONTENT.value())
     }
 
-    @Disabled("Need to fix that ORM uses `user` column name without escaping (reserved on SQL Server)")
     @Test
     @DisplayName("Should process if user with provided email exists")
     fun shouldProcess_whenUserExists() {

--- a/server/src/apiTest/resources/sql/cleanup_base_test_data.sql
+++ b/server/src/apiTest/resources/sql/cleanup_base_test_data.sql
@@ -4,5 +4,8 @@ WHERE creator_id IN (SELECT id FROM users WHERE uid = 'hanna_test_1@example.com'
 DELETE FROM user_authorities
 WHERE user_id IN (SELECT id FROM users WHERE uid = 'hanna_test_1@example.com');
 
+DELETE FROM reset_password_tokens
+WHERE app_user IN (SELECT id FROM users WHERE uid = 'hanna_test_1@example.com');
+
 DELETE FROM users
 WHERE uid = 'hanna_test_1@example.com';

--- a/server/src/main/kotlin/org/hkurh/doky/password/db/ResetPasswordTokenEntity.kt
+++ b/server/src/main/kotlin/org/hkurh/doky/password/db/ResetPasswordTokenEntity.kt
@@ -19,7 +19,7 @@ import java.util.*
     indexes = [Index(name = "idx_reset_password_tokens_token", columnList = "token")],
     uniqueConstraints = [
         UniqueConstraint(name = "uc_reset_password_tokens_token", columnNames = ["token"]),
-        UniqueConstraint(name = "uc_reset_password_tokens_user", columnNames = ["user"])]
+        UniqueConstraint(name = "uc_reset_password_tokens_app_user", columnNames = ["app_user"])]
 )
 class ResetPasswordTokenEntity {
 
@@ -29,7 +29,7 @@ class ResetPasswordTokenEntity {
     var id: Long = -1
 
     @OneToOne
-    @JoinColumn(name = "user")
+    @JoinColumn(name = "app_user")
     var user: UserEntity? = null
 
     @Column(name = "token")

--- a/server/src/main/kotlin/org/hkurh/doky/password/impl/DefaultPasswordFacade.kt
+++ b/server/src/main/kotlin/org/hkurh/doky/password/impl/DefaultPasswordFacade.kt
@@ -16,7 +16,10 @@ class DefaultPasswordFacade(
 ) : PasswordFacade {
 
     override fun reset(email: String) {
-        if (!userService.exists(email)) return
+        if (!userService.exists(email)) {
+            LOG.debug { "Requested reset password token for non existing user" }
+            return
+        }
 
         val user = userService.findUserByUid(email)
         val resetToken = resetPasswordService.generateAndSaveResetToken(user!!)

--- a/server/src/main/resources/db/migration/sqlserver/V1_4__rename_user_column_in_reset_password.sql
+++ b/server/src/main/resources/db/migration/sqlserver/V1_4__rename_user_column_in_reset_password.sql
@@ -1,0 +1,32 @@
+ALTER TABLE reset_password_tokens
+    DROP CONSTRAINT FK_RESET_PASSWORD_TOKENS_ON_USER
+GO
+
+ALTER TABLE reset_password_tokens
+    ADD app_user bigint
+GO
+
+ALTER TABLE reset_password_tokens
+    ADD CONSTRAINT uc_reset_password_tokens_app_user UNIQUE (app_user)
+GO
+
+ALTER TABLE reset_password_tokens
+    ADD CONSTRAINT FK_RESET_PASSWORD_TOKENS_ON_APP_USER FOREIGN KEY (app_user) REFERENCES users (id)
+GO
+
+ALTER TABLE reset_password_tokens
+    DROP CONSTRAINT uc_reset_password_tokens_user
+GO
+
+DECLARE @sql [nvarchar](MAX)
+SELECT @sql = N'ALTER TABLE reset_password_tokens DROP CONSTRAINT ' + QUOTENAME([df].[name])
+FROM [sys].[columns] AS [c]
+         INNER JOIN [sys].[default_constraints] AS [df] ON [df].[object_id] = [c].[default_object_id]
+WHERE [c].[object_id] = OBJECT_ID(N'reset_password_tokens')
+  AND [c].[name] = N'[user]'
+EXEC sp_executesql @sql
+GO
+
+ALTER TABLE reset_password_tokens
+    DROP COLUMN [user]
+GO


### PR DESCRIPTION
Rename `user` column to `app_user` in reset password tables

Updated the `reset_password_tokens` table to rename the `user` column to `app_user` to address SQL Server reserved keyword issues. Adjusted entity classes, test specifications, and SQL scripts accordingly.