### PR TITLE
DOKY-178 Add message to Kafka to send email

### DIFF
--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -20,6 +20,7 @@ plugins {
 dependencyManagement {
     imports {
         mavenBom("com.azure.spring:spring-cloud-azure-dependencies:5.3.0")
+        mavenBom("org.springframework.boot:spring-boot-dependencies:3.1.2")
     }
 }
 
@@ -88,6 +89,9 @@ dependencies {
 
     implementation("com.azure:azure-storage-blob:12.25.3")
 
+    implementation("org.apache.kafka:kafka-clients")
+    implementation("org.springframework.kafka:spring-kafka")
+
     implementation("net.logstash.logback:logstash-logback-encoder:7.4")
 
     runtimeOnly("org.springframework.boot:spring-boot-devtools")
@@ -100,7 +104,7 @@ dependencies {
     testImplementation("org.mockito.kotlin:mockito-kotlin:5.0.0")
     testImplementation("com.icegreen:greenmail:2.0.1")
     testImplementation("org.awaitility:awaitility:4.2.1")
-
+    testImplementation("org.springframework.kafka:spring-kafka-test")
     testImplementation("io.rest-assured:rest-assured:5.3.0")
 }
 
@@ -140,6 +144,10 @@ testing {
 
                 implementation("com.icegreen:greenmail:2.0.1")
                 implementation("org.awaitility:awaitility:4.2.1")
+
+                implementation("org.springframework.kafka:spring-kafka-test")
+                implementation("org.apache.kafka:kafka-clients")
+                implementation("org.springframework.kafka:spring-kafka")
             }
         }
         register<JvmTestSuite>("apiTest") {
@@ -157,6 +165,10 @@ testing {
                 implementation("org.mockito:mockito-junit-jupiter:4.0.0")
                 implementation("org.mockito.kotlin:mockito-kotlin:5.0.0")
                 implementation("io.rest-assured:rest-assured:5.3.0")
+
+                implementation("org.springframework.kafka:spring-kafka-test")
+                implementation("org.apache.kafka:kafka-clients")
+                implementation("org.springframework.kafka:spring-kafka")
             }
         }
     }

--- a/server/src/apiTest/kotlin/org/hkurh/doky/EmbeddedKafkaConsumerConfig.kt
+++ b/server/src/apiTest/kotlin/org/hkurh/doky/EmbeddedKafkaConsumerConfig.kt
@@ -1,0 +1,45 @@
+package org.hkurh.doky
+
+import org.apache.kafka.clients.CommonClientConfigs
+import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.common.config.SaslConfigs
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.support.serializer.JsonDeserializer
+
+@Configuration
+class EmbeddedKafkaConsumerConfig {
+
+    @Value("\${spring.kafka.bootstrap-servers}")
+    private var bootstrapServer: String = ""
+
+    @Value("\${spring.kafka.properties.security.protocol}")
+    private var securityProtocol: String = ""
+
+    @Value("\${spring.kafka.properties.sasl.mechanism}")
+    private var saslMechanism: String = ""
+
+    @Value("\${spring.kafka.properties.sasl.jaas.config}")
+    private var saslConfig: String = ""
+
+    @Bean
+    fun kafkaConsumer(): Consumer<String, Any> {
+        val configProps = mutableMapOf<String, Any>(
+            ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG to bootstrapServer,
+            CommonClientConfigs.SECURITY_PROTOCOL_CONFIG to securityProtocol,
+            SaslConfigs.SASL_MECHANISM to saslMechanism,
+            SaslConfigs.SASL_JAAS_CONFIG to saslConfig,
+            ConsumerConfig.GROUP_ID_CONFIG to "test-group",
+            ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to "earliest",
+            JsonDeserializer.TRUSTED_PACKAGES to "org.hkurh.doky.kafka",
+            ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG to StringDeserializer::class.java,
+            ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG to JsonDeserializer::class.java
+        )
+
+        return KafkaConsumer(configProps)
+    }
+}

--- a/server/src/apiTest/kotlin/org/hkurh/doky/RestSpec.kt
+++ b/server/src/apiTest/kotlin/org/hkurh/doky/RestSpec.kt
@@ -11,16 +11,20 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.kafka.test.context.EmbeddedKafka
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.context.jdbc.SqlMergeMode
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig
 
 @ActiveProfiles("test")
 @Tag("api")
 @Suite
 @SuiteDisplayName("API Tests")
 @IncludeTags("api")
+@SpringJUnitConfig
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@EmbeddedKafka(topics = ["emails-test"])
 @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
 @Sql(scripts = ["classpath:sql/create_base_test_data.sql"], executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
 @Sql(scripts = ["classpath:sql/cleanup_base_test_data.sql"], executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)

--- a/server/src/integrationTest/kotlin/org/hkurh/doky/DokyIntegrationTest.kt
+++ b/server/src/integrationTest/kotlin/org/hkurh/doky/DokyIntegrationTest.kt
@@ -5,16 +5,20 @@ import org.junit.platform.suite.api.IncludeTags
 import org.junit.platform.suite.api.Suite
 import org.junit.platform.suite.api.SuiteDisplayName
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.kafka.test.context.EmbeddedKafka
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.context.jdbc.SqlMergeMode
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig
 
 @ActiveProfiles("test")
 @Tag("integration")
 @Suite
 @SuiteDisplayName("Integration Tests")
 @IncludeTags("integration")
+@SpringJUnitConfig
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@EmbeddedKafka(topics = ["emails-test"])
 @SqlMergeMode(SqlMergeMode.MergeMode.MERGE)
 @Sql(scripts = ["classpath:sql/create_base_test_data.sql"], executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
 @Sql(scripts = ["classpath:sql/cleanup_base_test_data.sql"], executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)

--- a/server/src/integrationTest/kotlin/org/hkurh/doky/EmbeddedKafkaConsumerConfig.kt
+++ b/server/src/integrationTest/kotlin/org/hkurh/doky/EmbeddedKafkaConsumerConfig.kt
@@ -1,0 +1,45 @@
+package org.hkurh.doky
+
+import org.apache.kafka.clients.CommonClientConfigs
+import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.common.config.SaslConfigs
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.support.serializer.JsonDeserializer
+
+@Configuration
+class EmbeddedKafkaConsumerConfig {
+
+    @Value("\${spring.kafka.bootstrap-servers}")
+    private var bootstrapServer: String = ""
+
+    @Value("\${spring.kafka.properties.security.protocol}")
+    private var securityProtocol: String = ""
+
+    @Value("\${spring.kafka.properties.sasl.mechanism}")
+    private var saslMechanism: String = ""
+
+    @Value("\${spring.kafka.properties.sasl.jaas.config}")
+    private var saslConfig: String = ""
+
+    @Bean
+    fun kafkaConsumer(): Consumer<String, Any> {
+        val configProps = mutableMapOf<String, Any>(
+            ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG to bootstrapServer,
+            CommonClientConfigs.SECURITY_PROTOCOL_CONFIG to securityProtocol,
+            SaslConfigs.SASL_MECHANISM to saslMechanism,
+            SaslConfigs.SASL_JAAS_CONFIG to saslConfig,
+            ConsumerConfig.GROUP_ID_CONFIG to "test-group",
+            ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to "earliest",
+            JsonDeserializer.TRUSTED_PACKAGES to "org.hkurh.doky.kafka",
+            ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG to StringDeserializer::class.java,
+            ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG to JsonDeserializer::class.java
+        )
+
+        return KafkaConsumer(configProps)
+    }
+}

--- a/server/src/integrationTest/kotlin/org/hkurh/doky/users/DefaultUserServiceIntegrationTest.kt
+++ b/server/src/integrationTest/kotlin/org/hkurh/doky/users/DefaultUserServiceIntegrationTest.kt
@@ -1,48 +1,53 @@
 package org.hkurh.doky.users
 
-import com.icegreen.greenmail.util.GreenMail
+import org.apache.kafka.clients.consumer.Consumer
 import org.awaitility.Awaitility.await
 import org.hkurh.doky.DokyIntegrationTest
-import org.hkurh.doky.SmtpServerExtension
 import org.hkurh.doky.users.impl.DefaultUserService
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.test.utils.KafkaTestUtils
 import org.springframework.test.context.jdbc.Sql
+import java.time.Duration.ofSeconds
 import java.util.concurrent.TimeUnit
 
-@ExtendWith(SmtpServerExtension::class)
 @DisplayName("DefaultUserService integration test")
 class DefaultUserServiceIntegrationTest : DokyIntegrationTest() {
 
     @Autowired
     lateinit var userService: DefaultUserService
 
-    var smtpServer: GreenMail? = null
+    @Autowired
+    lateinit var kafkaTemplate: KafkaTemplate<String, Any>
+
+    @Autowired
+    lateinit var messageConsumer: Consumer<String, Any>
+
+    private val topic = "emails-test"
 
     @Test
-    @DisplayName("Should sent registration email when register new user")
+    @DisplayName("Should sent email notification when register new user")
     @Sql(
         scripts = ["classpath:sql/UserServiceIntegrationTest/cleanup.sql"],
         executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD
     )
-    fun shouldSendRegistrationEmail_whenRegisterNewUser() {
+    fun shouldSendEmailNotification_whenRegisterNewUser() {
         // given
         val userEmail = "hkurh.test.01@yopmail.com"
+        messageConsumer.subscribe(listOf(topic))
+        Thread.sleep(3_000)
 
         // when
         userService.create(userEmail, "password")
 
         // then
-        await().atMost(10, TimeUnit.SECONDS).until { smtpServer!!.receivedMessages.isNotEmpty() }
-        smtpServer!!.apply {
-            assertNotNull(receivedMessages, "No emails sent")
-            assertEquals(1, receivedMessages.size, "Incorrect amount of messages")
-            val message = receivedMessages[0]
-            assertEquals(userEmail, message.allRecipients[0].toString())
+        await().atMost(1, TimeUnit.MINUTES).untilAsserted {
+            val message = KafkaTestUtils.getSingleRecord(messageConsumer, topic, ofSeconds(10))
+            assertNotNull(message, "No messages received")
         }
+        messageConsumer.close()
     }
 }

--- a/server/src/main/kotlin/org/hkurh/doky/KafkaProducerConfig.kt
+++ b/server/src/main/kotlin/org/hkurh/doky/KafkaProducerConfig.kt
@@ -1,0 +1,50 @@
+package org.hkurh.doky
+
+import org.apache.kafka.clients.CommonClientConfigs
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.config.SaslConfigs
+import org.apache.kafka.common.serialization.StringSerializer
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.annotation.EnableKafka
+import org.springframework.kafka.core.DefaultKafkaProducerFactory
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.core.ProducerFactory
+import org.springframework.kafka.support.serializer.JsonSerializer
+
+@EnableKafka
+@Configuration
+class KafkaProducerConfig {
+
+    @Value("\${spring.kafka.bootstrap-servers}")
+    private var bootstrapServer: String = ""
+
+    @Value("\${spring.kafka.properties.security.protocol}")
+    private var securityProtocol: String = ""
+
+    @Value("\${spring.kafka.properties.sasl.mechanism}")
+    private var saslMechanism: String = ""
+
+    @Value("\${spring.kafka.properties.sasl.jaas.config}")
+    private var saslConfig: String = ""
+
+    @Bean
+    fun producerFactory(): ProducerFactory<String, Any> {
+        val configProps = mutableMapOf<String, Any>(
+            ProducerConfig.BOOTSTRAP_SERVERS_CONFIG to bootstrapServer,
+            CommonClientConfigs.SECURITY_PROTOCOL_CONFIG to securityProtocol,
+            SaslConfigs.SASL_MECHANISM to saslMechanism,
+            SaslConfigs.SASL_JAAS_CONFIG to saslConfig,
+            ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG to StringSerializer::class.java,
+            ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG to JsonSerializer::class.java
+        )
+        return DefaultKafkaProducerFactory(configProps)
+    }
+
+    @Bean
+    fun kafkaTemplate(): KafkaTemplate<String, Any> {
+        return KafkaTemplate(producerFactory())
+    }
+}
+

--- a/server/src/main/kotlin/org/hkurh/doky/kafka/KafkaEmailNotificationService.kt
+++ b/server/src/main/kotlin/org/hkurh/doky/kafka/KafkaEmailNotificationService.kt
@@ -1,0 +1,41 @@
+package org.hkurh.doky.kafka
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.support.SendResult
+import org.springframework.stereotype.Component
+import java.util.concurrent.CompletableFuture
+
+@Component
+class KafkaEmailNotificationService(
+    private val kafkaTemplate: KafkaTemplate<String, Any>
+) {
+
+    @Value("\${doky.kafka.topic.emails}")
+    private var topic: String = ""
+
+    fun sendNotification(userId: Long, emailType: EmailType) {
+        val key = "$userId"
+        val message = SendEmailMessage().apply {
+            this.userId = userId
+            this.emailType = emailType
+        }
+        sendKafkaMessage(key, message)
+    }
+
+    private fun sendKafkaMessage(key: String, message: SendEmailMessage) {
+        val future: CompletableFuture<SendResult<String, Any>> = kafkaTemplate.send(topic, key, message)
+        future.whenComplete { result, e ->
+            if (e == null) {
+                LOG.debug { "Produced message to topic [${result.recordMetadata.topic()}] with key [$key]" }
+            } else {
+                LOG.error(e) { "Error sending reset password email message with key [$key]" }
+            }
+        }
+    }
+
+    companion object {
+        private val LOG = KotlinLogging.logger {}
+    }
+}

--- a/server/src/main/kotlin/org/hkurh/doky/kafka/SendEmailMessage.kt
+++ b/server/src/main/kotlin/org/hkurh/doky/kafka/SendEmailMessage.kt
@@ -1,0 +1,16 @@
+package org.hkurh.doky.kafka
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+class SendEmailMessage {
+    @JsonProperty("userId")
+    var userId: Long? = null
+
+    @JsonProperty("emailType")
+    var emailType: EmailType? = null
+}
+
+enum class EmailType {
+    REGISTRATION,
+    RESET_PASSWORD
+}

--- a/server/src/main/kotlin/org/hkurh/doky/password/impl/DefaultPasswordFacade.kt
+++ b/server/src/main/kotlin/org/hkurh/doky/password/impl/DefaultPasswordFacade.kt
@@ -1,18 +1,19 @@
 package org.hkurh.doky.password.impl
 
 import io.github.oshai.kotlinlogging.KotlinLogging
-import org.hkurh.doky.email.EmailService
+import org.hkurh.doky.kafka.EmailType
+import org.hkurh.doky.kafka.KafkaEmailNotificationService
 import org.hkurh.doky.password.PasswordFacade
 import org.hkurh.doky.password.ResetPasswordService
 import org.hkurh.doky.users.UserService
-import org.hkurh.doky.users.db.UserEntity
 import org.springframework.stereotype.Component
+
 
 @Component
 class DefaultPasswordFacade(
     private val userService: UserService,
     private val resetPasswordService: ResetPasswordService,
-    private val emailService: EmailService
+    private val kafkaEmailNotificationService: KafkaEmailNotificationService
 ) : PasswordFacade {
 
     override fun reset(email: String) {
@@ -22,17 +23,9 @@ class DefaultPasswordFacade(
         }
 
         val user = userService.findUserByUid(email)
-        val resetToken = resetPasswordService.generateAndSaveResetToken(user!!)
+        resetPasswordService.generateAndSaveResetToken(user!!)
         LOG.debug { "Generate reset password token for user [${user.id}]" }
-        sendResetPasswordEmail(user, resetToken)
-    }
-
-    private fun sendResetPasswordEmail(user: UserEntity, resetToken: String) {
-        try {
-            emailService.sendRestorePasswordEmail(user, resetToken)
-        } catch (e: Exception) {
-            LOG.error(e) { "Error sending reset password email for user ${user.id}" }
-        }
+        kafkaEmailNotificationService.sendNotification(user.id, EmailType.RESET_PASSWORD)
     }
 
 

--- a/server/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/server/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -104,6 +104,11 @@
       "name": "spring.cloud.azure.appconfiguration.stores[0].monitoring.triggers[0].key",
       "type": "java.lang.String",
       "description": "Description for spring.cloud.azure.appconfiguration.stores[0].monitoring.triggers[0].key."
+    },
+    {
+      "name": "doky.kafka.topic.emails",
+      "type": "java.lang.String",
+      "description": "Description for doky.kafka.topic.emails."
     }
   ],
   "hints": [

--- a/server/src/main/resources/application-local.properties
+++ b/server/src/main/resources/application-local.properties
@@ -14,9 +14,9 @@ spring.mail.password=""
 # spa resources routing
 doky.static.caching=false
 spring.web.resources.cache.period=0s
-
+# kafka
+doky.kafka.topic.emails=emails-test
 
 logging.level.web=DEBUG
 logging.level.org.hkurh.doky=DEBUG
 logging.level.org.hkurh.doky.security.JwtAuthorizationFilter=DEBUG
-

--- a/server/src/main/resources/application-test.properties
+++ b/server/src/main/resources/application-test.properties
@@ -7,5 +7,11 @@ spring.mail.host=localhost
 spring.mail.port=2525
 spring.mail.username=""
 spring.mail.password=""
+# kafka
+spring.kafka.bootstrap-servers=${spring.embedded.kafka.brokers}
+spring.kafka.properties.security.protocol=PLAINTEXT
+spring.kafka.properties.sasl.mechanism=PLAIN
+spring.kafka.properties.sasl.jaas.config=
+doky.kafka.topic.emails=emails-test
 # logging
 logging.level.org.hkurh.doky=DEBUG

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -45,3 +45,12 @@ management.endpoints.web.base-path=/api/actuator
 # spa resources routing
 spring.mvc.throw-exception-if-no-handler-found=true
 spring.web.resources.add-mappings=true
+# Required connection configs for Kafka producer, consumer, and admin
+#doky.kafka.username=<CHANGE_ME>
+#doky.kafka.password=<CHANGE_ME>
+spring.kafka.properties.sasl.mechanism=PLAIN
+#spring.kafka.bootstrap-servers=<CHANGE_ME>
+spring.kafka.properties.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username='${doky.kafka.username}' password='${doky.kafka.password}';
+spring.kafka.properties.security.protocol=SASL_SSL
+spring.kafka.properties.session.timeout.ms=45000
+doky.kafka.topic.emails=emails

--- a/server/src/test/kotlin/org/hkurh/doky/kafka/KafkaEmailNotificationServiceTest.kt
+++ b/server/src/test/kotlin/org/hkurh/doky/kafka/KafkaEmailNotificationServiceTest.kt
@@ -1,0 +1,48 @@
+package org.hkurh.doky.kafka
+
+import org.hkurh.doky.DokyUnitTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.support.SendResult
+import java.util.concurrent.CompletableFuture
+
+@DisplayName("KafkaEmailNotificationService unit test")
+class KafkaEmailNotificationServiceTest : DokyUnitTest {
+
+    private val kafkaTemplate: KafkaTemplate<String, Any> = mock()
+    private val kafkaEmailNotificationService = KafkaEmailNotificationService(kafkaTemplate)
+
+    @Test
+    @DisplayName("Should send message to kafka")
+    fun shouldSendMessageToKafka() {
+        // given
+        val userId = 16L
+        whenever(
+            kafkaTemplate.send(
+                any<String>(),
+                eq(userId.toString()),
+                any<SendEmailMessage>()
+            )
+        ).thenAnswer { invocation ->
+            val argument = invocation.getArgument<SendEmailMessage>(2)
+            assertEquals(userId, argument.userId)
+            assertEquals(EmailType.RESET_PASSWORD, argument.emailType)
+            CompletableFuture<SendResult<String, Any>>()
+        }
+
+        // when
+        kafkaEmailNotificationService.sendNotification(userId, EmailType.RESET_PASSWORD)
+
+        // then
+        verify(kafkaTemplate, times(1)).send(any(), eq(userId.toString()), any())
+
+    }
+}

--- a/server/src/test/kotlin/org/hkurh/doky/password/DefaultPasswordFacadeTest.kt
+++ b/server/src/test/kotlin/org/hkurh/doky/password/DefaultPasswordFacadeTest.kt
@@ -1,7 +1,8 @@
 package org.hkurh.doky.password
 
 import org.hkurh.doky.DokyUnitTest
-import org.hkurh.doky.email.EmailService
+import org.hkurh.doky.kafka.EmailType
+import org.hkurh.doky.kafka.KafkaEmailNotificationService
 import org.hkurh.doky.password.impl.DefaultPasswordFacade
 import org.hkurh.doky.users.UserService
 import org.hkurh.doky.users.db.UserEntity
@@ -13,17 +14,18 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 
-@DisplayName("DefaultPasswordFacadeTest unit test")
+@DisplayName("DefaultPasswordFacade unit test")
 class DefaultPasswordFacadeTest : DokyUnitTest {
 
     private val userService: UserService = mock()
     private val resetPasswordService: ResetPasswordService = mock()
-    private val emailService: EmailService = mock()
-    private var passwordFacade = DefaultPasswordFacade(userService, resetPasswordService, emailService)
+    private val kafkaEmailNotificationService: KafkaEmailNotificationService = mock()
+    private val passwordFacade = DefaultPasswordFacade(userService, resetPasswordService, kafkaEmailNotificationService)
 
     private val userEmail = "test@example.com"
     private val generatedToken = "token"
     private val userEntity = UserEntity().apply {
+        id = 14
         uid = userEmail
     }
 
@@ -54,7 +56,7 @@ class DefaultPasswordFacadeTest : DokyUnitTest {
         passwordFacade.reset(userEmail)
 
         // then
-        verify(emailService, times(1)).sendRestorePasswordEmail(userEntity, generatedToken)
+        verify(kafkaEmailNotificationService, times(1)).sendNotification(userEntity.id, EmailType.RESET_PASSWORD)
     }
 
     @Test
@@ -68,6 +70,6 @@ class DefaultPasswordFacadeTest : DokyUnitTest {
 
         // then
         verifyNoMoreInteractions(resetPasswordService)
-        verifyNoMoreInteractions(emailService)
+        verifyNoMoreInteractions(kafkaEmailNotificationService)
     }
 }


### PR DESCRIPTION
Add Kafka integration for email notifications

Added Kafka producer configurations for email notifications. Implemented Kafka email notification service and integrated it in user registration and password reset flows. Updated tests to incorporate Kafka messages.