### PR TITLE
DOKY-172 Create separate email service

### DIFF
--- a/email-service/build.gradle.kts
+++ b/email-service/build.gradle.kts
@@ -5,9 +5,12 @@ val springAzureVersion = "5.16.0"
 
 val kotlinLoggingVersion = "6.0.9"
 
-var greenmailVersion = "2.0.1"
-var awaitilityVersion = "4.2.1"
+val greenmailVersion = "2.0.1"
+val awaitilityVersion = "4.2.1"
 val junitSuiteVersion = "1.10.2"
+val jupiterVersion = "5.8.2"
+val mockitoJupiterVersion = "4.0.0"
+val mockitoKotlinVersion = "5.0.0"
 
 plugins {
     kotlin("jvm") version "1.9.25"
@@ -50,6 +53,7 @@ configurations {
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-mail")
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
@@ -71,10 +75,10 @@ dependencies {
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.kafka:spring-kafka-test")
-    testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
+    testImplementation("org.junit.jupiter:junit-jupiter:$jupiterVersion")
     testImplementation("org.junit.platform:junit-platform-suite-api:$junitSuiteVersion")
-    testImplementation("org.mockito:mockito-junit-jupiter:4.0.0")
-    testImplementation("org.mockito.kotlin:mockito-kotlin:5.0.0")
+    testImplementation("org.mockito:mockito-junit-jupiter:$mockitoJupiterVersion")
+    testImplementation("org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion")
     testImplementation("com.icegreen:greenmail:$greenmailVersion")
     testImplementation("org.awaitility:awaitility:$awaitilityVersion")
 

--- a/email-service/src/main/resources/application.properties
+++ b/email-service/src/main/resources/application.properties
@@ -1,7 +1,6 @@
 # local port to start server
 server.port=8080
 spring.application.name=email-service
-spring.main.web-application-type=none
 #doky.app.host=
 # database
 spring.session.jdbc.initialize-schema=never
@@ -33,3 +32,5 @@ doky.kafka.emails.group.id=doky-email-service
 doky.kafka.emails.consumer.id=email-notification-consumer
 doky.kafka.emails.consumer.autostart=true
 doky.kafka.emails.concurrency=3
+# actuator
+management.endpoints.enabled-by-default=true


### PR DESCRIPTION
Add Spring Boot Web Starter and enable Actuator endpoints

Refactor `build.gradle.kts` to include Spring Boot Web Starter and improve dependency management by using version variables. Enable Actuator endpoints by default in `application.properties` to support monitoring needs.