### PR TITLE
DOKY-186 Send emails using SendGrid REST API

### DIFF
--- a/email-service/build.gradle.kts
+++ b/email-service/build.gradle.kts
@@ -4,6 +4,7 @@ val springDependencyVersion = "1.1.6"
 val springAzureVersion = "5.16.0"
 
 val kotlinLoggingVersion = "6.0.9"
+val sendgridVersion = "4.10.1"
 
 val greenmailVersion = "2.0.1"
 val awaitilityVersion = "4.2.1"
@@ -65,6 +66,7 @@ dependencies {
     implementation("io.github.oshai:kotlin-logging:$kotlinLoggingVersion")
     implementation("org.apache.kafka:kafka-clients")
     implementation("com.fasterxml.jackson.core:jackson-annotations")
+    implementation("com.sendgrid:sendgrid-java:$sendgridVersion")
 
     developmentOnly("org.springframework.boot:spring-boot-devtools")
 

--- a/email-service/src/integrationTest/kotlin/org/hkurh/doky/kafka/KafkaEmailNotificationConsumerServiceIntegrationTest.kt
+++ b/email-service/src/integrationTest/kotlin/org/hkurh/doky/kafka/KafkaEmailNotificationConsumerServiceIntegrationTest.kt
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeUnit
 @DisplayName("KafkaEmailNotificationConsumerService integration test")
 class KafkaEmailNotificationConsumerServiceIntegrationTest : DokyIntegrationTest() {
 
-    val userEmail = "hanna_test_1@example.com"
+    val userEmail = "hanna_test_1@yopmail.com"
 
     var smtpServer: GreenMail? = null
 

--- a/email-service/src/integrationTest/resources/sql/KafkaEmailNotificationConsumerServiceIntegrationTest/setup.sql
+++ b/email-service/src/integrationTest/resources/sql/KafkaEmailNotificationConsumerServiceIntegrationTest/setup.sql
@@ -1,2 +1,2 @@
 INSERT IGNORE INTO reset_password_tokens (token, app_user)
-SELECT  "reset-token", u.id FROM users u WHERE u.uid = "hanna_test_1@example.com";
+SELECT  "reset-token", u.id FROM users u WHERE u.uid = "hanna_test_1@yopmail.com";

--- a/email-service/src/integrationTest/resources/sql/cleanup_base_test_data.sql
+++ b/email-service/src/integrationTest/resources/sql/cleanup_base_test_data.sql
@@ -1,7 +1,7 @@
-DELETE d FROM documents d INNER JOIN users u ON d.creator_id = u.id WHERE u.uid = "hanna_test_1@example.com";
+DELETE d FROM documents d INNER JOIN users u ON d.creator_id = u.id WHERE u.uid = "hanna_test_1@yopmail.com";
 
 DELETE FROM reset_password_tokens;
 
-DELETE a FROM user_authorities a INNER JOIN users u on a.user_id = u.id WHERE u.uid = "hanna_test_1@example.com";
+DELETE a FROM user_authorities a INNER JOIN users u on a.user_id = u.id WHERE u.uid = "hanna_test_1@yopmail.com";
 
-DELETE u FROM users u WHERE u.uid = "hanna_test_1@example.com";
+DELETE u FROM users u WHERE u.uid = "hanna_test_1@yopmail.com";

--- a/email-service/src/integrationTest/resources/sql/create_base_test_data.sql
+++ b/email-service/src/integrationTest/resources/sql/create_base_test_data.sql
@@ -1,6 +1,6 @@
-INSERT IGNORE INTO users (uid, name, password) VALUES ("hanna_test_1@example.com", "Hanna", "$2a$10$bdZSuBncZqaM4XwHcjxbpeQuXeOxk6vCEsFrTwa91xh3M3JpvW41m");
+INSERT IGNORE INTO users (uid, name, password) VALUES ("hanna_test_1@yopmail.com", "Hanna", "$2a$10$bdZSuBncZqaM4XwHcjxbpeQuXeOxk6vCEsFrTwa91xh3M3JpvW41m");
 
 INSERT IGNORE INTO user_authorities (user_id, authority_id)
 SELECT u.id, a.id
 FROM users u, authorities a
-WHERE a.authority = 'ROLE_USER' AND u.uid = "hanna_test_1@example.com"
+WHERE a.authority = 'ROLE_USER' AND u.uid = "hanna_test_1@yopmail.com"

--- a/email-service/src/main/kotlin/org/hkurh/doky/email/EmailProperties.kt
+++ b/email-service/src/main/kotlin/org/hkurh/doky/email/EmailProperties.kt
@@ -1,0 +1,40 @@
+package org.hkurh.doky.email
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+
+@Component
+@ConfigurationProperties(prefix = "doky.email")
+class EmailProperties {
+    lateinit var sender: Sender
+    lateinit var registration: Registration
+    lateinit var resetPassword: ResetPassword
+    lateinit var sendgrid: Sendgrid
+
+    class Sender {
+        lateinit var email: String
+        lateinit var name: String
+    }
+
+    class Registration {
+        lateinit var subject: String
+        lateinit var sendgrid: Sendgrid
+
+        class Sendgrid {
+            lateinit var templateId: String
+        }
+    }
+
+    class ResetPassword {
+        lateinit var subject: String
+        lateinit var sendgrid: Sendgrid
+
+        class Sendgrid {
+            lateinit var templateId: String
+        }
+    }
+
+    class Sendgrid {
+        lateinit var apiKey: String
+    }
+}

--- a/email-service/src/main/kotlin/org/hkurh/doky/email/impl/DefaultEmailService.kt
+++ b/email-service/src/main/kotlin/org/hkurh/doky/email/impl/DefaultEmailService.kt
@@ -1,9 +1,11 @@
 package org.hkurh.doky.email.impl
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import org.hkurh.doky.email.EmailProperties
 import org.hkurh.doky.email.EmailService
 import org.hkurh.doky.users.db.UserEntity
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.core.io.Resource
 import org.springframework.mail.javamail.JavaMailSender
 import org.springframework.mail.javamail.MimeMessageHelper
@@ -14,30 +16,25 @@ import java.nio.charset.StandardCharsets
 
 
 @Service
+@ConditionalOnProperty(name = ["doky.email.server.type"], havingValue = "smtp", matchIfMissing = true)
 class DefaultEmailService(
+    val emailProperties: EmailProperties,
+    @Value("\${doky.app.host}") val host: String,
+    @Value("classpath:/mail/img/logo-white-no-bg.svg") val logoFile: Resource,
     val emailSender: JavaMailSender,
     val templateEngine: SpringTemplateEngine
 ) : EmailService {
 
-    @Value("\${doky.app.host}")
-    lateinit var host: String
-
-    @Value("\${doky.email.from}")
-    lateinit var fromEmail: String
-
-    @Value("classpath:/mail/img/logo-white-no-bg.svg")
-    lateinit var logoFile: Resource
-
     override fun sendRegistrationConfirmationEmail(user: UserEntity) {
         LOG.debug { "Send registration email for user [${user.id}]" }
         val htmlBody = prepareRegistrationConfirmationEmail(user)
-        sendEmail(htmlBody, user.uid, "Doky Registration")
+        sendEmail(htmlBody, user.uid, emailProperties.registration.subject)
     }
 
     override fun sendRestorePasswordEmail(user: UserEntity, token: String) {
         LOG.debug { "Send reset password email for user [${user.id}]" }
         val htmlBody = prepareRestorePasswordEmail(user, token)
-        sendEmail(htmlBody, user.uid, "Doky Restore Password")
+        sendEmail(htmlBody, user.uid, emailProperties.resetPassword.subject)
     }
 
     private fun sendEmail(emailTemplate: String, toEmail: String, subject: String) {
@@ -47,7 +44,7 @@ class DefaultEmailService(
             MimeMessageHelper.MULTIPART_MODE_MIXED_RELATED,
             StandardCharsets.UTF_8.name()
         ).apply {
-            setFrom(fromEmail)
+            setFrom(emailProperties.sender.email, emailProperties.sender.name)
             setTo(toEmail)
             setSubject(subject)
             setText(emailTemplate, true)
@@ -72,7 +69,7 @@ class DefaultEmailService(
         val variables = HashMap<String, Any>().apply {
             user.name?.let { put("username", it) }
             put("restoreLink", "$host/password/update?token=$token")
-            put("mailto", fromEmail)
+            put("mailto", emailProperties.sender.email)
         }
         val context = Context().apply {
             setVariables(variables)

--- a/email-service/src/main/kotlin/org/hkurh/doky/email/impl/SendgridEmailService.kt
+++ b/email-service/src/main/kotlin/org/hkurh/doky/email/impl/SendgridEmailService.kt
@@ -1,0 +1,103 @@
+package org.hkurh.doky.email.impl
+
+import com.sendgrid.Method
+import com.sendgrid.Request
+import com.sendgrid.Response
+import com.sendgrid.SendGrid
+import com.sendgrid.helpers.mail.Mail
+import com.sendgrid.helpers.mail.objects.Email
+import com.sendgrid.helpers.mail.objects.Personalization
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.hkurh.doky.email.EmailProperties
+import org.hkurh.doky.email.EmailService
+import org.hkurh.doky.users.db.UserEntity
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Service
+import java.io.IOException
+
+
+@Service
+@ConditionalOnProperty(name = ["doky.email.server.type"], havingValue = "sendgrid", matchIfMissing = false)
+class SendgridEmailService(
+    val emailProperties: EmailProperties,
+    @Value("\${doky.app.host}") val host: String
+) : EmailService {
+
+    val defaultUserName = "Customer"
+
+    override fun sendRegistrationConfirmationEmail(user: UserEntity) {
+        LOG.debug { "Send registration email for user [${user.id}]" }
+        sendEmail(
+            senderEmail = emailProperties.sender.email,
+            senderName = emailProperties.sender.name,
+            recipientEmail = user.uid,
+            subject = emailProperties.registration.subject,
+            templateId = emailProperties.registration.sendgrid.templateId,
+            dynamicData = mapOf("User_Name" to (user.name ?: defaultUserName))
+        )
+    }
+
+    override fun sendRestorePasswordEmail(user: UserEntity, token: String) {
+        LOG.debug { "Send reset password email for user [${user.id}]" }
+        sendEmail(
+            senderEmail = emailProperties.sender.email,
+            senderName = emailProperties.sender.name,
+            recipientEmail = user.uid,
+            subject = emailProperties.resetPassword.subject,
+            templateId = emailProperties.resetPassword.sendgrid.templateId,
+            dynamicData = mapOf(
+                "User_Name" to (user.name ?: defaultUserName),
+                "Reset_Password_Link" to generateResetPasswordLink(token)
+            )
+        )
+    }
+
+    private fun sendEmail(
+        senderEmail: String,
+        senderName: String,
+        recipientEmail: String,
+        subject: String,
+        templateId: String,
+        dynamicData: Map<String, String>
+    ) {
+        val sender = Email(senderEmail, senderName)
+        val to = Email(recipientEmail)
+
+        val personalization = Personalization().apply {
+            dynamicData.forEach { (key, value) -> addDynamicTemplateData(key, value) }
+            addTo(to)
+        }
+
+        val mail = Mail().apply {
+            from = sender
+            this.subject = subject
+            this.templateId = templateId
+            addPersonalization(personalization)
+        }
+
+        sendEmailToSendGrid(mail)
+    }
+
+    private fun generateResetPasswordLink(token: String): String {
+        return "$host/password/update?token=$token"
+    }
+
+    fun sendEmailToSendGrid(mail: Mail) {
+        val sendGridClient = SendGrid(emailProperties.sendgrid.apiKey)
+        val request = Request()
+        try {
+            request.method = Method.POST
+            request.endpoint = "mail/send"
+            request.body = mail.build()
+            val response: Response = sendGridClient.api(request)
+            LOG.debug { "RESPONSE code ${response.statusCode}; body ${response.body}" }
+        } catch (e: IOException) {
+            LOG.error { e.message }
+        }
+    }
+
+    companion object {
+        private val LOG = KotlinLogging.logger {}
+    }
+}

--- a/email-service/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/email-service/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -11,7 +11,12 @@
       "description": "Description for spring.kafka.session.timeout.ms."
     },
     {
-      "name": "doky.email.from",
+      "name": "doky.email.sender.email",
+      "type": "java.lang.String",
+      "description": "Description for doky.email.from."
+    },
+    {
+      "name": "doky.email.sender.name",
       "type": "java.lang.String",
       "description": "Description for doky.email.from."
     },
@@ -44,6 +49,51 @@
       "name": "doky.kafka.emails.concurrency",
       "type": "java.lang.Integer",
       "description": "Description for doky.kafka.emails.concurrency."
+    },
+    {
+      "name": "doky.email.server.type",
+      "type": "java.lang.String",
+      "description": "Description for doky.emailserver.type."
+    },
+    {
+      "name": "doky.email.registration.sendgrid.template-id",
+      "type": "java.lang.String",
+      "description": "Description for doky.email.registration.sendgrid.template-id."
+    },
+    {
+      "name": "doky.email.registration.subject",
+      "type": "java.lang.String",
+      "description": "Description for doky.email.registration.subject."
+    },
+    {
+      "name": "doky.email.reset-password.sendgrid.template-id",
+      "type": "java.lang.String",
+      "description": "Description for doky.email.reset-password.sendgrid.template-id."
+    },
+    {
+      "name": "doky.email.reset-password.subject",
+      "type": "java.lang.String",
+      "description": "Description for doky.email.reset-password.subject."
+    },
+    {
+      "name": "doky.email.sendgrid.api-key",
+      "type": "java.lang.String",
+      "description": "Description for doky.email.sendgrid.api-key."
+    }
+  ],
+  "hints": [
+    {
+      "name": "doky.email.server.type",
+      "values": [
+        {
+          "value": "smtp",
+          "description": "Use SMTP server to send emails."
+        },
+        {
+          "value": "sendgrid",
+          "description": "Use SendGrind API to send emails."
+        }
+      ]
     }
   ]
 }

--- a/email-service/src/main/resources/application-test.properties
+++ b/email-service/src/main/resources/application-test.properties
@@ -10,6 +10,8 @@ spring.mail.host=localhost
 spring.mail.port=2525
 spring.mail.username=""
 spring.mail.password=""
+doky.email.server.type=smtp
+doky.email.sendgrid.api-key="api-key"
 # kafka
 spring.kafka.bootstrap-servers=${spring.embedded.kafka.brokers}
 spring.kafka.properties.security.protocol=PLAINTEXT

--- a/email-service/src/main/resources/application.properties
+++ b/email-service/src/main/resources/application.properties
@@ -15,8 +15,14 @@ spring.mail.username=apikey
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 spring.thymeleaf.check-template-location=false
-doky.email.from=doky-dev@outlook.com
+doky.email.sender.email=doky-dev@outlook.com
+doky.email.sender.name=Doky Team
 doky.email.templates.path=mail/templates/
+doky.email.server.type=sendgrid
+doky.email.registration.sendgrid.template-id=d-a445db8eb8ac4d86ba38277ac2bb82da
+doky.email.registration.subject=Welcome to Doky
+doky.email.reset-password.sendgrid.template-id=d-9306f59a51b6457a950419b28525ab91
+doky.email.reset-password.subject=Doky Reset Password Request
 # kafka
 #doky.kafka.username=<CHANGE_ME>
 #doky.kafka.password=<CHANGE_ME>

--- a/email-service/src/test/kotlin/org/hkurh/doky/email/impl/DefaultEmailServiceTest.kt
+++ b/email-service/src/test/kotlin/org/hkurh/doky/email/impl/DefaultEmailServiceTest.kt
@@ -1,0 +1,85 @@
+package org.hkurh.doky.email.impl
+
+import jakarta.mail.internet.MimeMessage
+import org.hkurh.doky.DokyUnitTest
+import org.hkurh.doky.email.EmailProperties
+import org.hkurh.doky.users.db.UserEntity
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.core.io.Resource
+import org.springframework.mail.javamail.JavaMailSender
+import org.thymeleaf.spring6.SpringTemplateEngine
+
+
+@DisplayName("DefaultEmailService unit test")
+class DefaultEmailServiceTest : DokyUnitTest {
+
+    private val emailProperties = EmailProperties().apply {
+        sender = EmailProperties.Sender().apply {
+            email = "email"
+            name = "name"
+        }
+        registration = EmailProperties.Registration().apply {
+            subject = "subject"
+            sendgrid = EmailProperties.Registration.Sendgrid().apply {
+                templateId = "templateId"
+            }
+        }
+        resetPassword = EmailProperties.ResetPassword().apply {
+            subject = "subject"
+            sendgrid = EmailProperties.ResetPassword.Sendgrid().apply {
+                templateId = "templateId"
+            }
+        }
+        sendgrid = EmailProperties.Sendgrid().apply {
+            apiKey = "apiKey"
+        }
+    }
+    private val host = "http://localhost:8080"
+    private val logoFile: Resource = mock()
+    private val emailSender: JavaMailSender = mock()
+    private val templateEngine: SpringTemplateEngine = mock()
+    private val mimeMessage: MimeMessage = mock()
+    private val defaultEmailService = DefaultEmailService(emailProperties, host, logoFile, emailSender, templateEngine)
+    private val user = UserEntity().apply {
+        name = "John"
+        uid = "test@mail.com"
+    }
+
+    @BeforeEach
+    fun setUp() {
+        whenever(logoFile.filename).thenReturn("logo.png")
+        val htmlBody = "htmlBody"
+        whenever(templateEngine.process(any<String>(), any())).thenReturn(htmlBody)
+        whenever(emailSender.createMimeMessage()).thenReturn(mimeMessage)
+    }
+
+    @Test
+    @DisplayName("Should send registration email")
+    fun shouldSendRegistrationEmail() {
+        // when
+        defaultEmailService.sendRegistrationConfirmationEmail(user)
+
+        // then
+        verify(emailSender, times(1)).send(mimeMessage)
+    }
+
+    @Test
+    @DisplayName("Should send reset password request email")
+    fun shouldSendResetPasswordRequestEmail() {
+        // given
+        val token = "token"
+
+        // when
+        defaultEmailService.sendRestorePasswordEmail(user, token)
+
+        // then
+        verify(emailSender, times(1)).send(mimeMessage)
+    }
+}

--- a/email-service/src/test/kotlin/org/hkurh/doky/email/impl/SendgridEmailServiceTest.kt
+++ b/email-service/src/test/kotlin/org/hkurh/doky/email/impl/SendgridEmailServiceTest.kt
@@ -1,0 +1,105 @@
+package org.hkurh.doky.email.impl
+
+import com.sendgrid.helpers.mail.Mail
+import org.hkurh.doky.DokyUnitTest
+import org.hkurh.doky.email.EmailProperties
+import org.hkurh.doky.users.db.UserEntity
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@DisplayName("SendgridEmailService unit test")
+class SendgridEmailServiceTest : DokyUnitTest {
+
+    private val emailProperties = EmailProperties().apply {
+        sender = EmailProperties.Sender().apply {
+            email = "email"
+            name = "name"
+        }
+        registration = EmailProperties.Registration().apply {
+            subject = "subject"
+            sendgrid = EmailProperties.Registration.Sendgrid().apply {
+                templateId = "templateId"
+            }
+        }
+        resetPassword = EmailProperties.ResetPassword().apply {
+            subject = "subject"
+            sendgrid = EmailProperties.ResetPassword.Sendgrid().apply {
+                templateId = "templateId"
+            }
+        }
+        sendgrid = EmailProperties.Sendgrid().apply {
+            apiKey = "apiKey"
+        }
+    }
+    private val host = "http://localhost:8080"
+    private val sendgridEmailService = SendgridEmailService(emailProperties, host)
+
+    @Test
+    @DisplayName("Should send registration email")
+    fun shouldSendRegistrationEmail() {
+        // given
+        val user = UserEntity().apply {
+            name = "John"
+            uid = "test@mail.com"
+        }
+
+        val sendgridEmailServiceSpy = spy(sendgridEmailService)
+        doNothing().whenever(sendgridEmailServiceSpy).sendEmailToSendGrid(any())
+
+        // when
+        sendgridEmailServiceSpy.sendRegistrationConfirmationEmail(user)
+
+        //then
+        argumentCaptor<Mail>().apply {
+            verify(sendgridEmailServiceSpy).sendEmailToSendGrid(capture())
+            val mail = firstValue
+            assertAll(
+                { assertEquals(emailProperties.registration.subject, mail.subject) },
+                { assertEquals(emailProperties.sender.email, mail.from.email) },
+                { assertEquals(emailProperties.sender.name, mail.from.name) },
+                { assertEquals(mail.personalization[0].tos[0].email, user.uid) },
+                { assertEquals(mail.personalization[0].dynamicTemplateData["User_Name"], user.name) }
+            )
+        }
+    }
+
+    @Test
+    @DisplayName("Should send reset password request email")
+    fun shouldSendResetPasswordRequestEmail() {
+        // given
+        val user = UserEntity().apply {
+            name = "John"
+            uid = "test@mail.com"
+        }
+        val token = "token"
+        val sendgridEmailServiceSpy = spy(sendgridEmailService)
+        doNothing().whenever(sendgridEmailServiceSpy).sendEmailToSendGrid(any())
+
+        // when
+        sendgridEmailServiceSpy.sendRestorePasswordEmail(user, token)
+
+        //then
+        argumentCaptor<Mail>().apply {
+            verify(sendgridEmailServiceSpy).sendEmailToSendGrid(capture())
+            val mail = firstValue
+            assertAll(
+                { assertEquals(emailProperties.registration.subject, mail.subject) },
+                { assertEquals(emailProperties.sender.email, mail.from.email) },
+                { assertEquals(emailProperties.sender.name, mail.from.name) },
+                { assertEquals(mail.personalization[0].tos[0].email, user.uid) },
+                { assertEquals(mail.personalization[0].dynamicTemplateData["User_Name"], user.name) },
+                { assertNotNull(mail.personalization[0].dynamicTemplateData["Reset_Password_Link"]) }
+            )
+        }
+    }
+}
+


### PR DESCRIPTION
Introduce SendGrid email service and update properties

Added support for sending emails via SendGrid, including the necessary configurations and properties. Refactored `DefaultEmailService` to use `EmailProperties` for more flexible email settings.