### PR TITLE
DOKY-203 Configure Datadog Database monitoring

### DIFF
--- a/app-server/build.gradle.kts
+++ b/app-server/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     implementation(libs.commons.io)
     implementation(libs.azure.blob)
     implementation(libs.bundles.kafka)
+    implementation(libs.dd.trace.api)
 
     annotationProcessor(libs.spring.boot.config.processor)
 

--- a/app-server/src/main/kotlin/org/hkurh/doky/documents/api/DocumentController.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/documents/api/DocumentController.kt
@@ -1,5 +1,6 @@
 package org.hkurh.doky.documents.api
 
+import datadog.trace.api.Trace
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.validation.Valid
 import org.hkurh.doky.documents.DocumentFacade
@@ -22,12 +23,14 @@ import java.net.MalformedURLException
 class DocumentController(private val documentFacade: DocumentFacade) : DocumentApi {
 
     @PostMapping("/{id}/upload")
+    @Trace(operationName = "document.upload")
     override fun uploadFile(@RequestBody file: MultipartFile, @PathVariable id: String): ResponseEntity<*> {
         documentFacade.saveFile(file, id)
         return ResponseEntity.ok<Any>(null)
     }
 
     @GetMapping("/{id}/download")
+    @Trace(operationName = "document.download")
     @Throws(IOException::class)
     override fun downloadFile(@PathVariable id: String): ResponseEntity<*> {
         return try {
@@ -47,6 +50,7 @@ class DocumentController(private val documentFacade: DocumentFacade) : DocumentA
     }
 
     @PostMapping
+    @Trace(operationName = "document.create")
     override fun create(@RequestBody @Valid document: DocumentRequest): ResponseEntity<*> {
         val createdDocument = documentFacade.createDocument(document.name, document.description)
         val resourceLocation = ServletUriComponentsBuilder.fromCurrentRequest()
@@ -55,12 +59,14 @@ class DocumentController(private val documentFacade: DocumentFacade) : DocumentA
     }
 
     @PutMapping("/{id}")
+    @Trace(operationName = "document.update")
     override fun update(@PathVariable id: String, @RequestBody @Valid document: DocumentRequest): ResponseEntity<*>? {
         documentFacade.update(id, document)
         return ResponseEntity.ok<Any>(null)
     }
 
     @GetMapping("/{id}")
+    @Trace(operationName = "document.get.single")
     override fun get(@PathVariable id: String): ResponseEntity<*> {
         val document = documentFacade.findDocument(id)
         return if (document != null) {
@@ -72,6 +78,7 @@ class DocumentController(private val documentFacade: DocumentFacade) : DocumentA
     }
 
     @GetMapping
+    @Trace(operationName = "document.get.all")
     override fun getAll(): ResponseEntity<*> {
         val documents = documentFacade.findAllDocuments()
         return ResponseEntity.ok(documents)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ azurewebapp = "1.7.1"
 dokka = "1.9.20"
 buildconfig = "5.3.5"
 node-gradle = "7.0.2"
+dd-trace-api = "[1.44.0,2.0.0)"
 
 [libraries]
 spring-boot-bom = { group = "org.springframework.boot", name = "spring-boot-dependencies", version.ref = "spring-boot" }
@@ -74,6 +75,7 @@ rest-assured = { group = "io.rest-assured", name = "rest-assured", version.ref =
 junit4 = { group = "junit", name = "junit", version.ref = "junit4" }
 logback-classic = { group = "ch.qos.logback", name = "logback-classic" }
 logback-encoder = { group = "net.logstash.logback", name = "logstash-logback-encoder", version.ref = "logback-encoder" }
+dd-trace-api = { group = "com.datadoghq", name = "dd-trace-api", version.ref = "dd-trace-api" }
 
 [bundles]
 logging = ["kotlin-logging", "logback-classic", "logback-encoder"]

--- a/teamcity/app-server.Dockerfile
+++ b/teamcity/app-server.Dockerfile
@@ -9,16 +9,25 @@ ENV DD_SERVICE=app-server
 ENV DD_ENV=prod
 ENV DD_VERSION=$DD_VERSION
 
-ARG DD_GIT_REPOSITORY_URL
-ARG DD_GIT_COMMIT_SHA
-ENV DD_GIT_REPOSITORY_URL=${DD_GIT_REPOSITORY_URL}
-ENV DD_GIT_COMMIT_SHA=${DD_GIT_COMMIT_SHA}
+LABEL com.datadoghq.tags.service=app-server
+LABEL com.datadoghq.tags.env=prod
+LABEL com.datadoghq.tags.version=$DD_VERSION
+
+ENV DD_TRACE_SQL_ENABLED=true
+ENV DD_DATABASE_MONITORING=true
+ENV DD_MSSQL_ENABLED=true
+
+ENV DD_LOGS_ENABLED=true
+ENV DD_IAST_ENABLED=true
+ENV DD_APPSEC_ENABLED=true
+ENV DD_PROFILING_ENABLED=true
+ENV DD_TRACE_ENABLED=true
+ENV DD_LOGS_INJECTION=true
+ENV DD_TRACE_SAMPLE_RATE=1
 
 EXPOSE 8080
 
 ARG JAR_FILE=app-server/build/libs/app-server.jar
 COPY ${JAR_FILE} app.jar
 
-ENTRYPOINT ["/app/datadog-init"]
-
-CMD ["java","-jar", "-Dspring.profiles.active=prod", "/app.jar"]
+CMD ["/app/datadog-init", "java", "-jar", "-Dspring.profiles.active=prod", "/app.jar"]


### PR DESCRIPTION
Add Datadog tracing and configuration

Introduce Datadog tracing for key API operations in `DocumentController` using `@Trace` annotations. Update Gradle dependencies and Dockerfile to enable Datadog features such as logs, profiling, and APM. Adjusted Docker entrypoint and commands to initialize Datadog.