### PR TITLE
DOKY-204 Update deployment for email-service

### DIFF
--- a/app-server/build.gradle.kts
+++ b/app-server/build.gradle.kts
@@ -126,11 +126,8 @@ tasks.named<Test>("integrationTest") {
     }
 }
 
-val deployVersion = if (project.hasProperty("deployVersion")) {
-    project.property("deployVersion") as String
-} else {
-    "Aardvark-v0.1"
-}
+val deployVersion = rootProject.extra["deployVersion"] as String
+val buildDate = rootProject.extra["buildDate"] as String
 
 buildConfig {
     packageName("org.hkurh.doky")
@@ -144,11 +141,13 @@ tasks {
             attributes(
                 "Manifest-Version" to "1.0",
                 "Main-Class" to "org.hkurh.doky.DokyApplication",
-                "Implementation-Title" to "Doky",
+                "Implementation-Title" to "Doky App Server",
                 "Implementation-Version" to deployVersion,
                 "Implementation-Vendor" to "hkurh-pets",
                 "Created-By" to "Kotlin Gradle",
-                "Built-By" to "Hanna Kurhuzenkava"
+                "Built-By" to "Hanna Kurhuzenkava",
+                "Build-Jdk" to "17",
+                "Build-Date" to buildDate
             )
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
 allprojects {
     repositories {
         mavenLocal()
@@ -6,6 +9,16 @@ allprojects {
 }
 
 group = "org.hkurh.doky"
+val deployVersion: String by extra {
+    if (project.hasProperty("deployVersion")) {
+        project.property("deployVersion") as String
+    } else {
+        "Aardvark-v0.1"
+    }
+}
+val buildDate: String by extra {
+    ZonedDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss Z"))
+}
 
 plugins {
     alias(libs.plugins.kotlin.jvm)

--- a/email-service/build.gradle.kts
+++ b/email-service/build.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    alias(libs.plugins.spring.boot)
+}
+
 dependencyManagement {
     imports {
         mavenBom(libs.spring.boot.bom.get().toString())
@@ -14,7 +18,6 @@ configurations {
 dependencies {
     implementation(project(":persistence"))
 
-    implementation(libs.bundles.spring.starter.web)
     implementation(libs.spring.boot.starter.data.jpa)
     implementation(libs.bundles.mail)
     implementation(libs.bundles.azure.keyvault)
@@ -77,5 +80,30 @@ tasks.named<Test>("integrationTest") {
     testLogging {
         showStandardStreams = true
         events("PASSED", "SKIPPED", "FAILED")
+    }
+}
+
+val deployVersion = rootProject.extra["deployVersion"] as String
+val buildDate = rootProject.extra["buildDate"] as String
+
+tasks {
+    jar {
+        manifest {
+            attributes(
+                "Manifest-Version" to "1.0",
+                "Main-Class" to "org.hkurh.doky.EmailServiceApplication",
+                "Implementation-Title" to "Doky Email Service",
+                "Implementation-Version" to deployVersion,
+                "Implementation-Vendor" to "hkurh-pets",
+                "Created-By" to "Kotlin Gradle",
+                "Built-By" to "Hanna Kurhuzenkava",
+                "Build-Jdk" to "17",
+                "Build-Date" to buildDate
+            )
+        }
+    }
+
+    assemble {
+        dependsOn(jar)
     }
 }

--- a/email-service/src/main/kotlin/org/hkurh/doky/EmailServiceApplication.kt
+++ b/email-service/src/main/kotlin/org/hkurh/doky/EmailServiceApplication.kt
@@ -1,6 +1,7 @@
 package org.hkurh.doky
 
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.WebApplicationType
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.context.annotation.Bean
@@ -30,5 +31,7 @@ class EmailServiceApplication {
 }
 
 fun main(args: Array<String>) {
-    runApplication<EmailServiceApplication>(*args)
+    runApplication<EmailServiceApplication>(*args) {
+        setWebApplicationType(WebApplicationType.NONE)
+    }
 }

--- a/email-service/src/main/resources/application.properties
+++ b/email-service/src/main/resources/application.properties
@@ -39,5 +39,3 @@ doky.kafka.emails.group.id=doky-email-service
 doky.kafka.emails.consumer.id=email-notification-consumer
 doky.kafka.emails.consumer.autostart=true
 doky.kafka.emails.concurrency=3
-# actuator
-management.endpoints.enabled-by-default=true

--- a/email-service/src/main/resources/logback-spring.xml
+++ b/email-service/src/main/resources/logback-spring.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <springProfile name="!prod">
+        <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+        <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+        <root level="info">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+    <springProfile name="prod">
+        <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+                <providers>
+                    <timestamp>
+                        <timeZone>UTC</timeZone>
+                    </timestamp>
+                    <loggerName/>
+                    <logLevel>
+                        <fieldName>status</fieldName>
+                    </logLevel>
+                    <threadName/>
+                    <stackTrace/>
+                    <message/>
+                    <nestedField>
+                        <fieldName>mdc</fieldName>
+                        <providers>
+                            <mdc/>
+                        </providers>
+                    </nestedField>
+                    <throwableClassName/>
+                </providers>
+            </encoder>
+        </appender>
+        <root level="info">
+            <appender-ref ref="stdout"/>
+        </root>
+    </springProfile>
+</configuration>

--- a/teamcity/email-service.Dockerfile
+++ b/teamcity/email-service.Dockerfile
@@ -4,7 +4,7 @@ COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
 ADD 'https://dtdg.co/latest-java-tracer' /dd_tracer/java/dd-java-agent.jar
 
 ARG DD_VERSION=Aardvark-v0.1
-ARG DD_SERVICE=app-server
+ARG DD_SERVICE=email-service
 ARG DD_ENV=prod
 
 ENV DD_SERVICE=$DD_SERVICE
@@ -27,9 +27,7 @@ ENV DD_TRACE_ENABLED=true
 ENV DD_LOGS_INJECTION=true
 ENV DD_TRACE_SAMPLE_RATE=1
 
-EXPOSE 8080
-
-ARG JAR_FILE=app-server/build/libs/app-server.jar
+ARG JAR_FILE=email-service/build/libs/email-service.jar
 COPY ${JAR_FILE} app.jar
 
 CMD ["/app/datadog-init", "java", "-jar", "-Dspring.profiles.active=$DD_ENV", "/app.jar"]


### PR DESCRIPTION
Set up non-web `email-service` and enhance observability

Configured `email-service` to run as a non-web application by disabling the web application type. Added a dedicated `Dockerfile` for `email-service` with Datadog integration and introduced a production-specific JSON logging configuration. Adjusted environment configurations to improve flexibility and maintain consistency across services.