### PR TITLE
DOKY-208 Update file download endpoint to use temporary download token

### DIFF
--- a/app-server/src/main/kotlin/org/hkurh/doky/documents/DocumentFacade.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/documents/DocumentFacade.kt
@@ -27,7 +27,7 @@ interface DocumentFacade {
      * @param id The ID of the document to update.
      * @param document The document request containing the updated information.
      */
-    fun update(id: String, document: DocumentRequest)
+    fun update(id: Long, document: DocumentRequest)
 
     /**
      * Finds a document with the specified ID.
@@ -35,7 +35,7 @@ interface DocumentFacade {
      * @param id The ID of the document to find.
      * @return The [DocumentResponse] object representing the found document, or null if the document is not found.
      */
-    fun findDocument(id: String): DocumentResponse?
+    fun findDocument(id: Long): DocumentResponse?
 
     /**
      * Retrieves a list of all documents.
@@ -51,17 +51,18 @@ interface DocumentFacade {
      * @param id The ID of the document to which the file should be attached.
      */
     @Transactional(propagation = Propagation.REQUIRED)
-    fun saveFile(file: MultipartFile, id: String)
+    fun saveFile(id: Long, file: MultipartFile)
 
     /**
-     * Retrieves the resource representing the file attached to the document with the specified ID.
+     * Retrieves the file associated with the specified document ID and authorized by the given token.
      *
-     * @param id The ID of the document.
-     * @return The [Resource] object representing the attached file, or null if the file is not found.
-     * @throws IOException If an I/O error occurs while retrieving the file.
+     * @param documentId The ID of the document whose file is being retrieved.
+     * @param token The authorization token used to verify the download request.
+     * @return A [Resource] representing the file associated with the specified document ID.
+     * @throws IOException If an error occurs while accessing the file.
      */
     @Throws(IOException::class)
-    fun getFile(id: String): Resource?
+    fun getFile(documentId: Long, token: String): Resource
 
     /**
      * Generates a download token for the specified document ID and current user.
@@ -69,5 +70,5 @@ interface DocumentFacade {
      * @param id The ID of the document for which the download token is being generated.
      * @return A string representing the generated download token.
      */
-    fun generateDownloadToken(id: String): String
+    fun generateDownloadToken(id: Long): String
 }

--- a/app-server/src/main/kotlin/org/hkurh/doky/documents/DocumentService.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/documents/DocumentService.kt
@@ -1,12 +1,12 @@
 package org.hkurh.doky.documents
 
 import org.hkurh.doky.documents.db.DocumentEntity
-import org.hkurh.doky.users.db.UserEntity
 
 /**
  * Represents a service for managing documents.
  */
 interface DocumentService {
+
     /**
      * Creates a document with the specified name and description.
      *
@@ -22,7 +22,7 @@ interface DocumentService {
      * @param id The ID of the document to find.
      * @return The [DocumentEntity] object representing the found document, or null if no document found.
      */
-    fun find(id: String): DocumentEntity?
+    fun find(id: Long): DocumentEntity?
 
     /**
      * Finds all documents.
@@ -38,12 +38,5 @@ interface DocumentService {
      */
     fun save(document: DocumentEntity)
 
-    /**
-     * Generates a download token for a specified document and user.
-     *
-     * @param user The [UserEntity] representing the user requesting the download token.
-     * @param document The [DocumentEntity] representing the document for which the token is generated.
-     * @return A string representing the generated download token.
-     */
-    fun generateDownloadToken(user: UserEntity, document: DocumentEntity): String
+
 }

--- a/app-server/src/main/kotlin/org/hkurh/doky/documents/DownloadTokenService.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/documents/DownloadTokenService.kt
@@ -1,0 +1,26 @@
+package org.hkurh.doky.documents
+
+import org.hkurh.doky.documents.db.DocumentEntity
+import org.hkurh.doky.users.db.UserEntity
+
+interface DownloadTokenService {
+
+    /**
+     * Generates a download token for a specified document and user.
+     *
+     * @param user The [UserEntity] representing the user requesting the download token.
+     * @param document The [DocumentEntity] representing the document for which the token is generated.
+     * @return A string representing the generated download token.
+     */
+    fun generateDownloadToken(user: UserEntity, document: DocumentEntity): String
+
+    /**
+     * Validates a download token for the specified document ID.
+     *
+     * @param documentId The ID of the document to validate the token against.
+     * @param token The download token to be validated.
+     * @return The [DocumentEntity] associated with the validated token.
+     * @throws IllegalArgumentException If the token is invalid or does not match the document.
+     */
+    fun validateDownloadTokenAndFetchDocument(documentId: Long, token: String): DocumentEntity
+}

--- a/app-server/src/main/kotlin/org/hkurh/doky/documents/api/DocumentApi.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/documents/api/DocumentApi.kt
@@ -24,14 +24,14 @@ interface DocumentApi {
         ApiResponse(responseCode = "200", description = "File is uploaded and attached to document"),
         ApiResponse(responseCode = "404", description = "Document with provided id does not exist")
     )
-    fun uploadFile(@RequestBody file: MultipartFile, @PathVariable id: String): ResponseEntity<*>?
+    fun uploadFile(@RequestBody file: MultipartFile, @PathVariable id: Long): ResponseEntity<*>?
 
     @Operation(summary = "Get token to authorize file download")
     @ApiResponses(
         ApiResponse(responseCode = "200", description = "Token is generated and provided"),
         ApiResponse(responseCode = "404", description = "Document with provided id does not exist")
     )
-    fun getDownloadToken(@PathVariable id: String): ResponseEntity<DownloadTokenResponse>?
+    fun getDownloadToken(@PathVariable id: Long): ResponseEntity<DownloadTokenResponse>?
 
     @Operation(summary = "Download file attached to document entry")
     @ApiResponses(
@@ -40,13 +40,14 @@ interface DocumentApi {
             content = [Content(mediaType = MediaType.APPLICATION_OCTET_STREAM_VALUE)],
             headers = [Header(name = "attachment; filename=...")]
         ),
+        ApiResponse(responseCode = "401", description = "Token is invalid or expired"),
         ApiResponse(
             responseCode = "404",
             description = "No document with requested id, or no attached file for document"
         )
     )
     @Throws(IOException::class)
-    fun downloadFile(@PathVariable id: String): ResponseEntity<*>?
+    fun downloadFile(@PathVariable id: Long, @RequestBody downloadFileRequest: DownloadFileRequest): ResponseEntity<*>?
 
     @Operation(summary = "Create document with metadata")
     @ApiResponses(ApiResponse(responseCode = "201", description = "Document is created"))
@@ -57,7 +58,7 @@ interface DocumentApi {
         ApiResponse(responseCode = "200", description = "Document is updated"),
         ApiResponse(responseCode = "404", description = "No document with provided id")
     )
-    fun update(@PathVariable id: String, document: DocumentRequest): ResponseEntity<*>?
+    fun update(@PathVariable id: Long, document: DocumentRequest): ResponseEntity<*>?
 
     @Operation(summary = "Get metadata for document")
     @ApiResponses(
@@ -67,7 +68,7 @@ interface DocumentApi {
         ),
         ApiResponse(responseCode = "404", description = "No document with provided id")
     )
-    operator fun get(@PathVariable id: String): ResponseEntity<*>?
+    operator fun get(@PathVariable id: Long): ResponseEntity<*>?
 
     @ApiResponses(
         ApiResponse(

--- a/app-server/src/main/kotlin/org/hkurh/doky/documents/api/DownloadFileRequest.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/documents/api/DownloadFileRequest.kt
@@ -1,0 +1,13 @@
+package org.hkurh.doky.documents.api
+
+import jakarta.validation.constraints.NotBlank
+
+/**
+ * Represents a request to download a file.
+ *
+ * @property token The token used to authorize the file download. This field cannot be blank.
+ */
+class DownloadFileRequest {
+    @NotBlank(message = "Token can not be blank")
+    var token: String = ""
+}

--- a/app-server/src/main/kotlin/org/hkurh/doky/documents/impl/DefaultDocumentService.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/documents/impl/DefaultDocumentService.kt
@@ -4,19 +4,13 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import org.hkurh.doky.documents.DocumentService
 import org.hkurh.doky.documents.db.DocumentEntity
 import org.hkurh.doky.documents.db.DocumentEntityRepository
-import org.hkurh.doky.documents.db.DownloadDocumentTokenEntity
-import org.hkurh.doky.documents.db.DownloadDocumentTokenEntityRepository
-import org.hkurh.doky.security.JwtProvider
 import org.hkurh.doky.users.UserService
-import org.hkurh.doky.users.db.UserEntity
 import org.springframework.stereotype.Service
 
 @Service
 class DefaultDocumentService(
     private val documentEntityRepository: DocumentEntityRepository,
-    private val downloadDocumentTokenEntityRepository: DownloadDocumentTokenEntityRepository,
     private val userService: UserService,
-    private val jwtProvider: JwtProvider
 ) : DocumentService {
 
     override fun create(name: String, description: String?): DocumentEntity {
@@ -30,10 +24,9 @@ class DefaultDocumentService(
         return savedDocument
     }
 
-    override fun find(id: String): DocumentEntity? {
-        val documentId = id.toLong()
+    override fun find(id: Long): DocumentEntity? {
         val currentUser = userService.getCurrentUser()
-        return documentEntityRepository.findByIdAndCreatorId(documentId, currentUser.id)
+        return documentEntityRepository.findByIdAndCreatorId(id, currentUser.id)
     }
 
     override fun find(): List<DocumentEntity> {
@@ -43,19 +36,6 @@ class DefaultDocumentService(
 
     override fun save(document: DocumentEntity) {
         documentEntityRepository.save(document)
-    }
-
-    override fun generateDownloadToken(user: UserEntity, document: DocumentEntity): String {
-        val token = jwtProvider.generateDownloadToken(user)
-        val tokenEntity =
-            downloadDocumentTokenEntityRepository.findByUserAndDocument(user, document) ?: DownloadDocumentTokenEntity()
-        tokenEntity.apply {
-            this.user = user
-            this.document = document
-            this.token = token
-        }
-        downloadDocumentTokenEntityRepository.save(tokenEntity)
-        return token
     }
 
     companion object {

--- a/app-server/src/main/kotlin/org/hkurh/doky/documents/impl/DefaultDownloadTokenService.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/documents/impl/DefaultDownloadTokenService.kt
@@ -1,0 +1,57 @@
+package org.hkurh.doky.documents.impl
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.hkurh.doky.documents.DocumentService
+import org.hkurh.doky.documents.DownloadTokenService
+import org.hkurh.doky.documents.db.DocumentEntity
+import org.hkurh.doky.documents.db.DownloadDocumentTokenEntity
+import org.hkurh.doky.documents.db.DownloadDocumentTokenEntityRepository
+import org.hkurh.doky.errorhandling.DokyInvalidTokenException
+import org.hkurh.doky.security.JwtProvider
+import org.hkurh.doky.users.UserService
+import org.hkurh.doky.users.db.UserEntity
+import org.springframework.stereotype.Service
+
+@Service
+class DefaultDownloadTokenService(
+    private val documentService: DocumentService,
+    private val userService: UserService,
+    private val downloadDocumentTokenEntityRepository: DownloadDocumentTokenEntityRepository,
+    private val jwtProvider: JwtProvider
+) : DownloadTokenService {
+
+    override fun generateDownloadToken(user: UserEntity, document: DocumentEntity): String {
+        val token = jwtProvider.generateDownloadToken(user)
+        val tokenEntity =
+            downloadDocumentTokenEntityRepository.findByUserAndDocument(user, document) ?: DownloadDocumentTokenEntity()
+        tokenEntity.apply {
+            this.user = user
+            this.document = document
+            this.token = token
+        }
+        downloadDocumentTokenEntityRepository.save(tokenEntity)
+        return token
+    }
+
+    override fun validateDownloadTokenAndFetchDocument(documentId: Long, token: String): DocumentEntity {
+        try {
+            if (!jwtProvider.isDownloadTokenValid(token)) throw DokyInvalidTokenException("Token is expired or invalid")
+        } catch (e: Exception) {
+            throw DokyInvalidTokenException("Error occurred during token validation: ${e.message}")
+        }
+
+        val user = userService.getCurrentUser()
+        val document =
+            documentService.find(documentId)
+                ?: throw DokyInvalidTokenException("Document with id [$documentId] not found")
+        val documentToken = downloadDocumentTokenEntityRepository.findByUserAndDocument(user, document)
+        if (documentToken == null || documentToken.token != token) {
+            throw DokyInvalidTokenException("Token [$token] is not valid for document [$documentId] and user [${user.id}]")
+        }
+        return document
+    }
+
+    companion object {
+        private val LOG = KotlinLogging.logger {}
+    }
+}

--- a/app-server/src/main/kotlin/org/hkurh/doky/errorhandling/DokyControllerAdvice.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/errorhandling/DokyControllerAdvice.kt
@@ -31,7 +31,7 @@ class DokyControllerAdvice {
     }
 
     @ExceptionHandler(DokyInvalidTokenException::class)
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
     fun badRequest(exception: Exception): ErrorResponse {
         return ErrorResponse(Error(exception.message!!))
     }

--- a/app-server/src/main/kotlin/org/hkurh/doky/filestorage/impl/DokyAzureBlobStorage.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/filestorage/impl/DokyAzureBlobStorage.kt
@@ -29,7 +29,7 @@ class DokyAzureBlobStorage : FileStorage {
 
     @PostConstruct
     fun init() {
-        LOG.debug { "Azure Blob container name $containerName initialized" }
+        LOG.debug { "Azure Blob container name [$containerName] initialized" }
         blobContainerClient = BlobContainerClientBuilder()
                 .connectionString(connectionString)
                 .containerName(containerName)

--- a/app-server/src/test/kotlin/org/hkurh/doky/documents/impl/DefaultDocumentFacadeTest.kt
+++ b/app-server/src/test/kotlin/org/hkurh/doky/documents/impl/DefaultDocumentFacadeTest.kt
@@ -2,6 +2,7 @@ package org.hkurh.doky.documents.impl
 
 import org.hkurh.doky.DokyUnitTest
 import org.hkurh.doky.documents.DocumentService
+import org.hkurh.doky.documents.DownloadTokenService
 import org.hkurh.doky.documents.api.DocumentRequest
 import org.hkurh.doky.documents.db.DocumentEntity
 import org.hkurh.doky.errorhandling.DokyNotFoundException
@@ -23,9 +24,11 @@ import org.mockito.kotlin.whenever
 class DefaultDocumentFacadeTest : DokyUnitTest {
 
     private var documentService: DocumentService = mock()
+    private var downloadTokenService: DownloadTokenService = mock()
     private var fileStorageService: FileStorageService = mock()
     private var userService: UserService = mock()
-    private var documentFacade = DefaultDocumentFacade(documentService, fileStorageService, userService)
+    private var documentFacade =
+        DefaultDocumentFacade(documentService, downloadTokenService, fileStorageService, userService)
 
     @BeforeEach
     fun setUp() {
@@ -36,9 +39,9 @@ class DefaultDocumentFacadeTest : DokyUnitTest {
     @DisplayName("Should update Document when it exists")
     fun shouldUpdateDocument_whenItExists() {
         // given
-        val originId = "1"
+        val originId: Long = 1
         val originDocument = DocumentEntity().apply {
-            id = originId.toLong()
+            id = originId
             name = "Test"
             description = "Description"
         }
@@ -65,12 +68,11 @@ class DefaultDocumentFacadeTest : DokyUnitTest {
         )
     }
 
-
     @Test
     @DisplayName("Should throw exception when update non existing document")
     fun shouldThrowException_whenUpdateNonExistingDocument() {
         // given
-        val originId = "1"
+        val originId: Long = 1
         val updatedDocument = DocumentRequest().apply {
             name = "Another Name"
             description = "Description for Document"


### PR DESCRIPTION
Refactor download token handling and enhance validation

Moved download token logic from `DocumentService` to a new `DownloadTokenService` to improve separation of concerns. Updated APIs to consistently use Long for IDs and introduced a more robust download token validation mechanism. Adjusted related tests and documentation for improved clarity and accuracy.