### PR TITLE
DOKY-206 Adjust error handling from SendGrid

### DIFF
--- a/email-service/src/main/kotlin/org/hkurh/doky/email/impl/SendgridEmailService.kt
+++ b/email-service/src/main/kotlin/org/hkurh/doky/email/impl/SendgridEmailService.kt
@@ -91,7 +91,10 @@ class SendgridEmailService(
             request.endpoint = "mail/send"
             request.body = mail.build()
             val response: Response = sendGridClient.api(request)
-            LOG.debug { "RESPONSE code ${response.statusCode}; body ${response.body}" }
+            LOG.debug { "Response code: ${response.statusCode}; body: ${response.body}" }
+            if (response.statusCode !in 200..299) {
+                LOG.error { "Error during sending email. Response code: ${response.statusCode}; body: ${response.body}" }
+            }
         } catch (e: IOException) {
             LOG.error { e.message }
         }

--- a/email-service/src/test/kotlin/org/hkurh/doky/email/impl/SendgridEmailServiceTest.kt
+++ b/email-service/src/test/kotlin/org/hkurh/doky/email/impl/SendgridEmailServiceTest.kt
@@ -58,7 +58,7 @@ class SendgridEmailServiceTest : DokyUnitTest {
         // when
         sendgridEmailServiceSpy.sendRegistrationConfirmationEmail(user)
 
-        //then
+        // then
         argumentCaptor<Mail>().apply {
             verify(sendgridEmailServiceSpy).sendEmailToSendGrid(capture())
             val mail = firstValue
@@ -87,7 +87,7 @@ class SendgridEmailServiceTest : DokyUnitTest {
         // when
         sendgridEmailServiceSpy.sendRestorePasswordEmail(user, token)
 
-        //then
+        // then
         argumentCaptor<Mail>().apply {
             verify(sendgridEmailServiceSpy).sendEmailToSendGrid(capture())
             val mail = firstValue
@@ -102,4 +102,3 @@ class SendgridEmailServiceTest : DokyUnitTest {
         }
     }
 }
-


### PR DESCRIPTION
Add handling for SendGrid API errors in email service

Enhanced error handling in `SendgridEmailService` to log errors for non-2xx responses from the SendGrid API.