### PR TITLE
DOKY-145 download file

### DIFF
--- a/app-server/doky-front/src/api/documents.js
+++ b/app-server/doky-front/src/api/documents.js
@@ -1,4 +1,4 @@
-import {get, post, postFormData, put} from './request';
+import {download, get, post, postFormData, put} from './request';
 
 const RESOURCE_NAME = 'documents';
 
@@ -11,3 +11,14 @@ export const createDocument = payload => post(RESOURCE_NAME, payload);
 export const updateDocument = payload => put(`${RESOURCE_NAME}/${payload.id}`, payload);
 
 export const uploadDocument = (documentId, formData) => postFormData(`${RESOURCE_NAME}/${documentId}/upload`, formData);
+
+export const downloadDocument = async documentId => {
+  const token = await getDownloadToken(documentId);
+  return download(`${RESOURCE_NAME}/${documentId}/download`, token);
+};
+
+export const getDownloadToken = async documentId => {
+  const { token } = await get(`${RESOURCE_NAME}/${documentId}/download/token`);
+  return token;
+};
+

--- a/app-server/doky-front/src/api/request.js
+++ b/app-server/doky-front/src/api/request.js
@@ -48,6 +48,16 @@ export const put = async (url, data = {}) =>
 
 export const get = async url => {
   const response = await fetch(BASE_URL + apiPrefix + '/' + url, getDefaultOptions());
-
   return response.json();
 };
+
+export const download = async (url, token) => {
+  const { body } = await fetch(BASE_URL + apiPrefix + '/' + url, {
+    ...getDefaultOptions('application/json'),
+    method: 'POST',
+    body: JSON.stringify({ token })
+  });
+
+  return body;
+};
+

--- a/app-server/doky-front/src/pages/Documents/EditDocumentForm/EditDocumentForm.jsx
+++ b/app-server/doky-front/src/pages/Documents/EditDocumentForm/EditDocumentForm.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import {useAddToast} from '../../../components/Toasts';
 import {useMutation} from '../../../hooks/useMutation.js';
-import {updateDocument, uploadDocument} from '../../../api/documents.js';
+import {updateDocument, uploadDocument, downloadDocument} from '../../../api/documents.js';
 import {useForm} from '../../../hooks/useForm.js';
 import AlertError from '../../../components/AlertError.jsx';
 import HorizontalFormInput from '../../../components/formComponents/HorizontalFormInput.jsx';
 import HorizontalFormText from '../../../components/formComponents/HorizontalFormText.jsx';
 import FileUploader from '../../../components/formComponents/FileUploader.jsx';
+import { saveFile } from '../../../services/save-file.js';
 
 const EditDocumentForm = ({document}) => {
   const [editDocument, {isLoading}] = useMutation(updateDocument);
@@ -31,6 +32,11 @@ const EditDocumentForm = ({document}) => {
 
   };
 
+  const handleDownload = async () => {
+    const body = await downloadDocument(document.id);
+    saveFile(body, document.fileName);
+  };
+
   return (
     <div className="container-fluid">
       <div className="row">
@@ -45,7 +51,7 @@ const EditDocumentForm = ({document}) => {
               <div>File:</div>
               <div>{document.fileName}</div>
               <div>
-                <button type="button" className="btn btn-outline-primary me-2" disabled={!document.fileName}>
+                <button type="button" className="btn btn-outline-primary me-2" disabled={!document.fileName} onClick={handleDownload}>
                   <i className="bi bi-cloud-download me-1"></i><span>Download</span>
                 </button>
                 <FileUploader onUpload={onUpload}/>

--- a/app-server/doky-front/src/services/save-file.js
+++ b/app-server/doky-front/src/services/save-file.js
@@ -1,0 +1,12 @@
+export const saveFile = async (body, fileName) => {
+  try {
+    const handleSave = await window.showSaveFilePicker({ suggestedName: fileName });
+    const writableStream = await handleSave.createWritable();
+    body.pipeTo(writableStream);
+  } catch {
+    /*
+     * Promise returned by window.showSaveFilePicker is rejected if user just close file picker.
+     * This is regular case. I don't think that we need to handle this somehow.
+     */
+  }
+};


### PR DESCRIPTION
## Implemented Approach
To meet the following requirements:

File download should be performed via POST request

Download request should contain a JSON body

Large files (current limit is 10 MB) can be downloaded

I decided to use the experimental browser API. The introduced approach allows receiving a readable stream and redirecting it to the file system.

https://developer.mozilla.org/en-US/docs/Web/API/Window/showSaveFilePicker
https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream/pipeTo

A disadvantage here is the poor integration with the browser UI: https://github.com/WICG/file-system-access/issues/379

## Alternatives
1. Fetch file content completely, convert it to base 64, insert it into a hidden link, and emulate a click. This is not appropriate due to excess memory usage.
2. Create a hidden form and emulate a submit. This is not appropriate because the request body should be JSON, not application/x-www-form-urlencoded.