### PR TITLE
DOKY-211 Switch CI/CD to node 22

### DIFF
--- a/app-server/build.gradle.kts
+++ b/app-server/build.gradle.kts
@@ -159,7 +159,7 @@ tasks {
 
 node {
     download = true
-    version = "20.12.2"
+    version = "22.13.1"
     npmInstallCommand = "ci"
     nodeProjectDir = file("${project.projectDir}/doky-front")
 }


### PR DESCRIPTION
Update `Node.js` version to `22.13.1` in `Gradle` build file

Upgraded `Node.js` from `20.12.2` to `22.13.1` in the build configuration. This ensures compatibility with the latest dependencies and introduces performance and security improvements. No other changes were made to the configuration.