### PR TITLE
DOKY-115 Add administrator user

### DIFF
--- a/indexer-service/src/integrationTest/kotlin/org/hkurh/doky/search/index/impl/DefaultIndexServiceIntegrationTest.kt
+++ b/indexer-service/src/integrationTest/kotlin/org/hkurh/doky/search/index/impl/DefaultIndexServiceIntegrationTest.kt
@@ -11,14 +11,14 @@ import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.`is`
 import org.hamcrest.Matchers.notNullValue
 import org.hkurh.doky.DokyIntegrationTest
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.context.annotation.Description
 import org.springframework.test.context.jdbc.Sql
 
-@Description("DefaultIndexServiceIntegration integration tests")
+@DisplayName("DefaultIndexServiceIntegration integration tests")
 class DefaultIndexServiceIntegrationTest : DokyIntegrationTest() {
 
     val azureSearchApiVersion = "2024-07-01"
@@ -30,7 +30,7 @@ class DefaultIndexServiceIntegrationTest : DokyIntegrationTest() {
     @Autowired
     lateinit var indexService: DefaultIndexService
 
-    @Description("Should delete all documents and re-index all documents")
+    @DisplayName("Should delete all documents and re-index all documents")
     @Test
     @Sql(
         scripts = ["classpath:sql/DefaultIndexServiceIntegrationTest/setup.sql"],

--- a/persistence/src/main/resources/migration/mysql/V1_6__add_admin_user.sql
+++ b/persistence/src/main/resources/migration/mysql/V1_6__add_admin_user.sql
@@ -1,0 +1,6 @@
+INSERT IGNORE INTO users (uid, name, password) VALUES ("hanna.kurhuzenkava@outlook.com", "Admin", "$2a$10$VFolreyF371093H1FJ28B.ugfQ0i/9EfZSZX0TTn.o9OGMJc1mK9K");
+
+INSERT IGNORE INTO user_authorities (user_id, authority_id)
+SELECT u.id, a.id
+FROM users u, authorities a
+WHERE a.authority = 'ROLE_ADMIN' AND u.uid = "hanna.kurhuzenkava@outlook.com";

--- a/persistence/src/main/resources/migration/sqlserver/V1_6__add_admin_user.sql
+++ b/persistence/src/main/resources/migration/sqlserver/V1_6__add_admin_user.sql
@@ -1,0 +1,22 @@
+IF NOT EXISTS (
+    SELECT 1 FROM users WHERE uid = 'hanna.kurhuzenkava@outlook.com'
+)
+BEGIN
+    INSERT INTO users (uid, name, password)
+    VALUES ('hanna.kurhuzenkava@outlook.com', 'Admin', '$2a$10$VFolreyF371093H1FJ28B.ugfQ0i/9EfZSZX0TTn.o9OGMJc1mK9K');
+END;
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM user_authorities ua
+    INNER JOIN users u ON u.id = ua.user_id
+    INNER JOIN authorities a ON a.id = ua.authority_id
+    WHERE u.uid = 'hanna.kurhuzenkava@outlook.com' AND a.authority = 'ROLE_ADMIN'
+)
+BEGIN
+    INSERT INTO user_authorities (user_id, authority_id)
+    SELECT u.id, a.id
+    FROM users u
+    INNER JOIN authorities a ON a.authority = 'ROLE_ADMIN'
+    WHERE u.uid = 'hanna.kurhuzenkava@outlook.com';
+END;


### PR DESCRIPTION
Add SQL scripts to insert default admin user

This commit introduces migration scripts for both SQL Server and MySQL to ensure a default admin user is created if it doesn't already exist. The user is assigned the `ROLE_ADMIN` authority to enable administrative privileges.