### PR TITLE
DOKY-216 Adjust logging and spring profile configurations for the production Docker environment

### DIFF
--- a/app-server/src/main/resources/logback-spring.xml
+++ b/app-server/src/main/resources/logback-spring.xml
@@ -1,37 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <springProfile name="!prod">
+    <springProfile name="!default">
         <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
         <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
         <root level="info">
             <appender-ref ref="CONSOLE"/>
         </root>
     </springProfile>
-    <springProfile name="prod">
+    <springProfile name="default">
         <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
-            <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
-                <providers>
-                    <timestamp>
-                        <timeZone>UTC</timeZone>
-                    </timestamp>
-                    <loggerName/>
-                    <logLevel>
-                        <fieldName>status</fieldName>
-                    </logLevel>
-                    <threadName/>
-                    <stackTrace/>
-                    <message/>
-                    <nestedField>
-                        <fieldName>mdc</fieldName>
-                        <providers>
-                            <mdc/>
-                        </providers>
-                    </nestedField>
-                    <throwableClassName/>
-                </providers>
+            <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                <fieldNames>
+                    <level>status</level>
+                    <exclude>version</exclude>
+                </fieldNames>
+                <includeMdcKeyName>true</includeMdcKeyName>
+                <timeZone>UTC</timeZone>
+                <timeStampFormat>yyyy-MM-dd'T'HH:mm:ss.SSS'Z'</timeStampFormat>
             </encoder>
         </appender>
-        <root level="info">
+        <root level="INFO">
             <appender-ref ref="stdout"/>
         </root>
     </springProfile>

--- a/email-service/src/main/resources/logback-spring.xml
+++ b/email-service/src/main/resources/logback-spring.xml
@@ -1,37 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <springProfile name="!prod">
+    <springProfile name="!default">
         <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
         <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
         <root level="info">
             <appender-ref ref="CONSOLE"/>
         </root>
     </springProfile>
-    <springProfile name="prod">
+    <springProfile name="default">
         <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
-            <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
-                <providers>
-                    <timestamp>
-                        <timeZone>UTC</timeZone>
-                    </timestamp>
-                    <loggerName/>
-                    <logLevel>
-                        <fieldName>status</fieldName>
-                    </logLevel>
-                    <threadName/>
-                    <stackTrace/>
-                    <message/>
-                    <nestedField>
-                        <fieldName>mdc</fieldName>
-                        <providers>
-                            <mdc/>
-                        </providers>
-                    </nestedField>
-                    <throwableClassName/>
-                </providers>
+            <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                <fieldNames>
+                    <level>status</level>
+                    <exclude>version</exclude>
+                </fieldNames>
+                <includeMdcKeyName>true</includeMdcKeyName>
+                <timeZone>UTC</timeZone>
+                <timeStampFormat>yyyy-MM-dd'T'HH:mm:ss.SSS'Z'</timeStampFormat>
             </encoder>
         </appender>
-        <root level="info">
+        <root level="INFO">
             <appender-ref ref="stdout"/>
         </root>
     </springProfile>

--- a/indexer-service/src/main/resources/logback-spring.xml
+++ b/indexer-service/src/main/resources/logback-spring.xml
@@ -1,37 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <springProfile name="!prod">
+    <springProfile name="!default">
         <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
         <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
         <root level="info">
             <appender-ref ref="CONSOLE"/>
         </root>
     </springProfile>
-    <springProfile name="prod">
+    <springProfile name="default">
         <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
-            <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
-                <providers>
-                    <timestamp>
-                        <timeZone>UTC</timeZone>
-                    </timestamp>
-                    <loggerName/>
-                    <logLevel>
-                        <fieldName>status</fieldName>
-                    </logLevel>
-                    <threadName/>
-                    <stackTrace/>
-                    <message/>
-                    <nestedField>
-                        <fieldName>mdc</fieldName>
-                        <providers>
-                            <mdc/>
-                        </providers>
-                    </nestedField>
-                    <throwableClassName/>
-                </providers>
+            <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                <fieldNames>
+                    <level>status</level>
+                    <exclude>version</exclude>
+                </fieldNames>
+                <includeMdcKeyName>true</includeMdcKeyName>
+                <timeZone>UTC</timeZone>
+                <timeStampFormat>yyyy-MM-dd'T'HH:mm:ss.SSS'Z'</timeStampFormat>
             </encoder>
         </appender>
-        <root level="info">
+        <root level="INFO">
             <appender-ref ref="stdout"/>
         </root>
     </springProfile>

--- a/teamcity/app-server.Dockerfile
+++ b/teamcity/app-server.Dockerfile
@@ -32,4 +32,4 @@ EXPOSE 8080
 ARG JAR_FILE=app-server/build/libs/app-server.jar
 COPY ${JAR_FILE} app.jar
 
-CMD ["/app/datadog-init", "java", "-jar", "-Dspring.profiles.active=$DD_ENV", "/app.jar"]
+CMD ["/app/datadog-init", "java", "-jar", "/app.jar"]

--- a/teamcity/email-service.Dockerfile
+++ b/teamcity/email-service.Dockerfile
@@ -27,7 +27,9 @@ ENV DD_TRACE_ENABLED=true
 ENV DD_LOGS_INJECTION=true
 ENV DD_TRACE_SAMPLE_RATE=1
 
+EXPOSE 8080
+
 ARG JAR_FILE=email-service/build/libs/email-service.jar
 COPY ${JAR_FILE} app.jar
 
-CMD ["/app/datadog-init", "java", "-jar", "-Dspring.profiles.active=$DD_ENV", "/app.jar"]
+CMD ["/app/datadog-init", "java", "-jar", "/app.jar"]

--- a/teamcity/indexer-service.Dockerfile
+++ b/teamcity/indexer-service.Dockerfile
@@ -27,7 +27,9 @@ ENV DD_TRACE_ENABLED=true
 ENV DD_LOGS_INJECTION=true
 ENV DD_TRACE_SAMPLE_RATE=1
 
+EXPOSE 8080
+
 ARG JAR_FILE=indexer-service/build/libs/indexer-service.jar
 COPY ${JAR_FILE} app.jar
 
-CMD ["/app/datadog-init", "java", "-jar", "-Dspring.profiles.active=$DD_ENV", "/app.jar"]
+CMD ["/app/datadog-init", "java", "-jar", "/app.jar"]


### PR DESCRIPTION
Update logging configurations and simplify Dockerfiles

Revised logback configurations to use a streamlined encoder and adjusted profile names for consistency. Simplified Dockerfiles by removing the spring profile argument from CMD and adding port exposure for services where appropriate. These changes standardize configuration and improve maintainability across services.