### PR TITLE
DOKY-199 Add Spring Boot Admin client to app-server

### DIFF
--- a/app-server/build.gradle.kts
+++ b/app-server/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     implementation(libs.azure.blob)
     implementation(libs.bundles.kafka)
     implementation(libs.dd.trace.api)
+    implementation(libs.spring.boot.admin)
 
     annotationProcessor(libs.spring.boot.config.processor)
 

--- a/app-server/src/main/resources/application.properties
+++ b/app-server/src/main/resources/application.properties
@@ -32,6 +32,8 @@ spring.security.user.password=<CHANGE_ME>
 doky.password.reset.token.duration=10
 # actuator
 management.endpoints.web.base-path=/api/actuator
+management.endpoints.web.exposure.include=*
+management.health.defaults.enabled=true
 # spa resources routing
 spring.mvc.throw-exception-if-no-handler-found=true
 spring.web.resources.add-mappings=true
@@ -44,3 +46,5 @@ spring.kafka.properties.sasl.jaas.config=org.apache.kafka.common.security.plain.
 spring.kafka.properties.security.protocol=SASL_SSL
 spring.kafka.properties.session.timeout.ms=45000
 doky.kafka.topic.emails=emails
+# spring boot admin
+spring.boot.admin.client.url=http://localhost:8811

--- a/email-service/build.gradle.kts
+++ b/email-service/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     implementation(libs.kotlin.reflect)
     implementation(libs.bundles.kafka)
     implementation(libs.bundles.json)
+    implementation(libs.spring.boot.admin)
 
     annotationProcessor(libs.spring.boot.config.processor)
 

--- a/email-service/src/main/resources/application.properties
+++ b/email-service/src/main/resources/application.properties
@@ -39,3 +39,9 @@ doky.kafka.emails.group.id=doky-email-service
 doky.kafka.emails.consumer.id=email-notification-consumer
 doky.kafka.emails.consumer.autostart=true
 doky.kafka.emails.concurrency=3
+# spring boot admin
+spring.boot.admin.client.url=http://localhost:8811
+# actuator
+management.endpoints.web.base-path=/api/actuator
+management.endpoints.web.exposure.include=*
+management.health.defaults.enabled=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ testcontainers-wiremock = "1.0-alpha-14"
 wiremock = "3.12.0"
 jackson-module-kotlin = "2.18.2"
 json-flattener = "0.17.1"
+spring-boot-admin = "3.1.2"
 
 [libraries]
 spring-boot-bom = { group = "org.springframework.boot", name = "spring-boot-dependencies", version.ref = "spring-boot" }
@@ -51,6 +52,7 @@ spring-boot-starter-security = { group = "org.springframework.boot", name = "spr
 spring-boot-starter-validation = { group = "org.springframework.boot", name = "spring-boot-starter-validation" }
 spring-boot-starter-test = { group = "org.springframework.boot", name = "spring-boot-starter-test" }
 spring-boot-config-processor = { group = "org.springframework.boot", name = "spring-boot-configuration-processor" }
+spring-boot-admin = { group = "de.codecentric", name = "spring-boot-admin-starter-client", version.ref = "spring-boot-admin" }
 spring-core = { group = "org.springframework", name = "spring-core" }
 spring-context = { group = "org.springframework", name = "spring-context" }
 spring-kafka-production = { group = "org.springframework.kafka", name = "spring-kafka" }

--- a/indexer-service/build.gradle.kts
+++ b/indexer-service/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     implementation(libs.bundles.kafka)
     implementation(libs.bundles.json)
     implementation(libs.bundles.azure.search)
+    implementation(libs.spring.boot.admin)
 
     annotationProcessor(libs.spring.boot.config.processor)
 

--- a/indexer-service/src/main/resources/application.properties
+++ b/indexer-service/src/main/resources/application.properties
@@ -19,3 +19,9 @@ doky.kafka.emails.group.id=doky-indexer-service
 doky.kafka.emails.consumer.id=documents-notification-consumer
 doky.kafka.emails.consumer.autostart=true
 doky.kafka.emails.concurrency=3
+# spring boot admin
+spring.boot.admin.client.url=http://localhost:8811
+# actuator
+management.endpoints.web.base-path=/api/actuator
+management.endpoints.web.exposure.include=*
+management.health.defaults.enabled=true


### PR DESCRIPTION
Add Spring Boot Admin support across services

Integrated Spring Boot Admin dependencies and configurations into email-service, app-server, and indexer-service. Updated `application.properties` files to include required settings for Actuator and Spring Boot Admin client. Adjusted `libs.versions.toml` to define the Spring Boot Admin version.