### PR TITLE
DOKY-230 Configure API Gateway on Azure

### DIFF
--- a/app-server/doky-front/README.md
+++ b/app-server/doky-front/README.md
@@ -10,7 +10,7 @@ LTS version of [Node.js](https://nodejs.org) should be installed. nvm is recomme
 * `npm start` - run client. URL to open in browser will be printed on console. By default, api pointing to **dev** (
   remote) back-end
 * `npm run start:local`- run client with api pointing to **local** back-end.
-* `npm run start:dev` - run client with api pointing to **dev** (remote) back-end.
+* `npm run start:remote` - run client with api pointing to **dev** (remote) back-end.
 * `npm run build` - assembling prod version. All assets will be saved in *dist* folder
 * `npm run serve` - run node server for serving static from *dist* folder. Useful for checking dev configured builds
   locally

--- a/app-server/doky-front/src/api/config.remote.js
+++ b/app-server/doky-front/src/api/config.remote.js
@@ -1,1 +1,1 @@
-export const BASE_URL = 'https://app-server.blackfield-1e13811b.westeurope.azurecontainerapps.io';
+export const BASE_URL = 'https://doky.azure-api.net/v1';


### PR DESCRIPTION
Update API base URL and correct npm script name

Changed the API base URL to the new endpoint for consistency with updated backend routing. Also fixed the `npm run start:remote` script name in the README to clarify its usage.