### PR TITLE
DOKY-232 Remove Spring Admin

### DIFF
--- a/app-server/src/main/resources/application.properties
+++ b/app-server/src/main/resources/application.properties
@@ -46,5 +46,3 @@ spring.kafka.properties.sasl.jaas.config=org.apache.kafka.common.security.plain.
 spring.kafka.properties.security.protocol=SASL_SSL
 spring.kafka.properties.session.timeout.ms=45000
 doky.kafka.topic.emails=emails
-# spring boot admin
-spring.boot.admin.client.url=http://localhost:8811

--- a/email-service/src/main/resources/application.properties
+++ b/email-service/src/main/resources/application.properties
@@ -39,8 +39,6 @@ doky.kafka.emails.group.id=doky-email-service
 doky.kafka.emails.consumer.id=email-notification-consumer
 doky.kafka.emails.consumer.autostart=true
 doky.kafka.emails.concurrency=3
-# spring boot admin
-spring.boot.admin.client.url=http://localhost:8811
 # actuator
 management.endpoints.web.base-path=/api/actuator
 management.endpoints.web.exposure.include=*

--- a/indexer-service/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/indexer-service/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,28 @@
+{
+  "properties": [
+    {
+      "name": "doky.kafka.emails.topic",
+      "type": "java.lang.String",
+      "description": "This is the Kafka topic used for email processing."
+    },
+    {
+      "name": "doky.kafka.emails.group.id",
+      "type": "java.lang.String",
+      "description": "This is the group ID for the Kafka consumer group used for email processing."
+    },
+    {
+      "name": "doky.kafka.emails.consumer.id",
+      "type": "java.lang.String",
+      "description": "This is the unique identifier for the Kafka consumer used for processing emails."
+    },
+    {
+      "name": "doky.kafka.emails.consumer.autostart",
+      "type": "java.lang.Boolean",
+      "description": "This property indicates whether the Kafka email consumer should start automatically."
+    },
+    {
+      "name": "doky.kafka.emails.concurrency",
+      "type": "java.lang.Integer",
+      "description": "This property specifies the level of concurrency for the Kafka email consumer, determining the number of threads processing email messages."
+    }
+  ] }

--- a/indexer-service/src/main/resources/application.properties
+++ b/indexer-service/src/main/resources/application.properties
@@ -19,8 +19,6 @@ doky.kafka.emails.group.id=doky-indexer-service
 doky.kafka.emails.consumer.id=documents-notification-consumer
 doky.kafka.emails.consumer.autostart=true
 doky.kafka.emails.concurrency=3
-# spring boot admin
-spring.boot.admin.client.url=http://localhost:8811
 # actuator
 management.endpoints.web.base-path=/api/actuator
 management.endpoints.web.exposure.include=*


### PR DESCRIPTION
Remove Spring Boot Admin client configuration

Spring Boot Admin client configuration was commented out and is no longer needed. This cleanup ensures the application properties files remain concise and free of unused configurations. It has no impact on the existing functionality.