### PR TITLE
DOKY-233 Add Copyright comments

### DIFF
--- a/ai-search/src/main/kotlin/org/hkurh/doky/AiSearchConfig.kt
+++ b/ai-search/src/main/kotlin/org/hkurh/doky/AiSearchConfig.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky
 
 import com.azure.core.credential.AzureKeyCredential

--- a/ai-search/src/main/kotlin/org/hkurh/doky/search/LoggingPolicy.kt
+++ b/ai-search/src/main/kotlin/org/hkurh/doky/search/LoggingPolicy.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.search
 
 import com.azure.core.http.HttpPipelineCallContext

--- a/app-server/src/apiTest/kotlin/org/hkurh/doky/DocumentSpec.kt
+++ b/app-server/src/apiTest/kotlin/org/hkurh/doky/DocumentSpec.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky
 
 import io.restassured.RestAssured.given

--- a/app-server/src/apiTest/kotlin/org/hkurh/doky/EmbeddedKafkaConsumerConfig.kt
+++ b/app-server/src/apiTest/kotlin/org/hkurh/doky/EmbeddedKafkaConsumerConfig.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky
 
 import org.apache.kafka.clients.CommonClientConfigs

--- a/app-server/src/apiTest/kotlin/org/hkurh/doky/LoginSpec.kt
+++ b/app-server/src/apiTest/kotlin/org/hkurh/doky/LoginSpec.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky
 
 import io.restassured.RestAssured.given

--- a/app-server/src/apiTest/kotlin/org/hkurh/doky/PasswordSpec.kt
+++ b/app-server/src/apiTest/kotlin/org/hkurh/doky/PasswordSpec.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky
 
 import io.restassured.RestAssured.given

--- a/app-server/src/apiTest/kotlin/org/hkurh/doky/RegistrationSpec.kt
+++ b/app-server/src/apiTest/kotlin/org/hkurh/doky/RegistrationSpec.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky
 
 import io.restassured.RestAssured.given

--- a/app-server/src/apiTest/kotlin/org/hkurh/doky/RestSpec.kt
+++ b/app-server/src/apiTest/kotlin/org/hkurh/doky/RestSpec.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky
 
 import io.restassured.RestAssured.given

--- a/app-server/src/apiTest/kotlin/org/hkurh/doky/UserSpec.kt
+++ b/app-server/src/apiTest/kotlin/org/hkurh/doky/UserSpec.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky
 
 import io.restassured.RestAssured.given

--- a/app-server/src/integrationTest/kotlin/org/hkurh/doky/DokyIntegrationTest.kt
+++ b/app-server/src/integrationTest/kotlin/org/hkurh/doky/DokyIntegrationTest.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky
 
 import org.junit.jupiter.api.Tag

--- a/app-server/src/integrationTest/kotlin/org/hkurh/doky/EmbeddedKafkaConsumerConfig.kt
+++ b/app-server/src/integrationTest/kotlin/org/hkurh/doky/EmbeddedKafkaConsumerConfig.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky
 
 import org.apache.kafka.clients.CommonClientConfigs

--- a/app-server/src/integrationTest/kotlin/org/hkurh/doky/password/impl/DefaultPasswordFacadeIntegrationTest.kt
+++ b/app-server/src/integrationTest/kotlin/org/hkurh/doky/password/impl/DefaultPasswordFacadeIntegrationTest.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.password.impl
 
 import org.hkurh.doky.DokyIntegrationTest

--- a/app-server/src/integrationTest/kotlin/org/hkurh/doky/users/DefaultUserServiceIntegrationTest.kt
+++ b/app-server/src/integrationTest/kotlin/org/hkurh/doky/users/DefaultUserServiceIntegrationTest.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.users
 
 import org.apache.kafka.clients.consumer.Consumer

--- a/app-server/src/main/kotlin/org/hkurh/doky/ApiDocumentationConfig.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/ApiDocumentationConfig.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition

--- a/app-server/src/main/kotlin/org/hkurh/doky/DokyApi.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/DokyApi.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky
 
 import io.swagger.v3.oas.annotations.Operation

--- a/app-server/src/main/kotlin/org/hkurh/doky/DokyApplication.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/DokyApplication.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky
 
 import io.jsonwebtoken.SignatureAlgorithm

--- a/app-server/src/main/kotlin/org/hkurh/doky/DokyController.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/DokyController.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky
 
 import org.springframework.web.bind.annotation.GetMapping

--- a/app-server/src/main/kotlin/org/hkurh/doky/DokyMapper.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/DokyMapper.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky
 
 import org.apache.commons.lang3.StringUtils

--- a/app-server/src/main/kotlin/org/hkurh/doky/DokyWebConfig.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/DokyWebConfig.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky
 
 import org.springframework.beans.factory.annotation.Value

--- a/app-server/src/main/kotlin/org/hkurh/doky/KafkaProducerConfig.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/KafkaProducerConfig.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky
 
 import org.apache.kafka.clients.CommonClientConfigs
@@ -47,4 +67,3 @@ class KafkaProducerConfig {
         return KafkaTemplate(producerFactory())
     }
 }
-

--- a/app-server/src/main/kotlin/org/hkurh/doky/authorization/AuthenticationRequest.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/authorization/AuthenticationRequest.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.authorization
 
 import jakarta.validation.constraints.NotBlank

--- a/app-server/src/main/kotlin/org/hkurh/doky/authorization/AuthenticationResponse.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/authorization/AuthenticationResponse.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.authorization
 
 /**

--- a/app-server/src/main/kotlin/org/hkurh/doky/authorization/AuthorizationUserApi.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/authorization/AuthorizationUserApi.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.authorization
 
 import io.swagger.v3.oas.annotations.Operation

--- a/app-server/src/main/kotlin/org/hkurh/doky/authorization/AuthorizationUserController.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/authorization/AuthorizationUserController.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.authorization
 
 import jakarta.validation.Valid

--- a/app-server/src/main/kotlin/org/hkurh/doky/documents/DocumentFacade.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/documents/DocumentFacade.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.documents
 
 import org.hkurh.doky.documents.api.DocumentRequest

--- a/app-server/src/main/kotlin/org/hkurh/doky/documents/DocumentService.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/documents/DocumentService.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.documents
 
 import org.hkurh.doky.documents.db.DocumentEntity

--- a/app-server/src/main/kotlin/org/hkurh/doky/documents/DownloadTokenService.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/documents/DownloadTokenService.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.documents
 
 import org.hkurh.doky.documents.db.DocumentEntity

--- a/app-server/src/main/kotlin/org/hkurh/doky/documents/api/DocumentApi.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/documents/api/DocumentApi.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.documents.api
 
 import io.swagger.v3.oas.annotations.Operation

--- a/app-server/src/main/kotlin/org/hkurh/doky/documents/api/DocumentController.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/documents/api/DocumentController.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.documents.api
 
 import datadog.trace.api.Trace

--- a/app-server/src/main/kotlin/org/hkurh/doky/documents/api/DocumentRequest.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/documents/api/DocumentRequest.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.documents.api
 
 import jakarta.validation.constraints.NotBlank

--- a/app-server/src/main/kotlin/org/hkurh/doky/documents/api/DocumentResponse.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/documents/api/DocumentResponse.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.documents.api
 
 /**

--- a/app-server/src/main/kotlin/org/hkurh/doky/documents/api/DownloadFileRequest.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/documents/api/DownloadFileRequest.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.documents.api
 
 import jakarta.validation.constraints.NotBlank

--- a/app-server/src/main/kotlin/org/hkurh/doky/documents/api/DownloadTokenResponse.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/documents/api/DownloadTokenResponse.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.documents.api
 
 /**

--- a/app-server/src/main/kotlin/org/hkurh/doky/documents/impl/DefaultDocumentFacade.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/documents/impl/DefaultDocumentFacade.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.documents.impl
 
 import io.github.oshai.kotlinlogging.KotlinLogging

--- a/app-server/src/main/kotlin/org/hkurh/doky/documents/impl/DefaultDocumentService.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/documents/impl/DefaultDocumentService.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.documents.impl
 
 import io.github.oshai.kotlinlogging.KotlinLogging

--- a/app-server/src/main/kotlin/org/hkurh/doky/documents/impl/DefaultDownloadTokenService.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/documents/impl/DefaultDownloadTokenService.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.documents.impl
 
 import io.github.oshai.kotlinlogging.KotlinLogging

--- a/app-server/src/main/kotlin/org/hkurh/doky/errorhandling/DokyControllerAdvice.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/errorhandling/DokyControllerAdvice.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.errorhandling
 
 import org.springframework.http.HttpStatus

--- a/app-server/src/main/kotlin/org/hkurh/doky/errorhandling/ErrorResponses.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/errorhandling/ErrorResponses.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.errorhandling
 
 data class ErrorResponse(var error: Error)

--- a/app-server/src/main/kotlin/org/hkurh/doky/errorhandling/Exceptions.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/errorhandling/Exceptions.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.errorhandling
 
 import org.springframework.security.core.AuthenticationException

--- a/app-server/src/main/kotlin/org/hkurh/doky/filestorage/FileStorage.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/filestorage/FileStorage.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.filestorage
 
 import org.springframework.web.multipart.MultipartFile

--- a/app-server/src/main/kotlin/org/hkurh/doky/filestorage/FileStorageService.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/filestorage/FileStorageService.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.filestorage
 
 import org.springframework.web.multipart.MultipartFile

--- a/app-server/src/main/kotlin/org/hkurh/doky/filestorage/impl/DefaultFileStorageService.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/filestorage/impl/DefaultFileStorageService.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.filestorage.impl
 
 import io.github.oshai.kotlinlogging.KotlinLogging

--- a/app-server/src/main/kotlin/org/hkurh/doky/filestorage/impl/DokyAzureBlobStorage.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/filestorage/impl/DokyAzureBlobStorage.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.filestorage.impl
 
 import com.azure.storage.blob.BlobContainerClient

--- a/app-server/src/main/kotlin/org/hkurh/doky/filestorage/impl/DokyLocalFilesystemStorage.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/filestorage/impl/DokyLocalFilesystemStorage.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.filestorage.impl
 
 import io.github.oshai.kotlinlogging.KotlinLogging

--- a/app-server/src/main/kotlin/org/hkurh/doky/kafka/KafkaEmailNotificationProducerService.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/kafka/KafkaEmailNotificationProducerService.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.kafka
 
 import io.github.oshai.kotlinlogging.KotlinLogging

--- a/app-server/src/main/kotlin/org/hkurh/doky/kafka/SendEmailMessage.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/kafka/SendEmailMessage.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.kafka
 
 import com.fasterxml.jackson.annotation.JsonProperty

--- a/app-server/src/main/kotlin/org/hkurh/doky/password/PasswordFacade.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/password/PasswordFacade.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.password
 
 /**

--- a/app-server/src/main/kotlin/org/hkurh/doky/password/ResetPasswordService.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/password/ResetPasswordService.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.password
 
 import org.hkurh.doky.errorhandling.DokyInvalidTokenException

--- a/app-server/src/main/kotlin/org/hkurh/doky/password/TokenService.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/password/TokenService.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.password
 
 import java.util.*

--- a/app-server/src/main/kotlin/org/hkurh/doky/password/api/PasswordApi.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/password/api/PasswordApi.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.password.api
 
 import io.swagger.v3.oas.annotations.Operation

--- a/app-server/src/main/kotlin/org/hkurh/doky/password/api/PasswordController.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/password/api/PasswordController.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.password.api
 
 import jakarta.validation.Valid

--- a/app-server/src/main/kotlin/org/hkurh/doky/password/api/ResetPasswordRequest.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/password/api/ResetPasswordRequest.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.password.api
 
 import jakarta.validation.constraints.NotBlank

--- a/app-server/src/main/kotlin/org/hkurh/doky/password/api/UpdatePasswordRequest.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/password/api/UpdatePasswordRequest.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.password.api
 
 import jakarta.validation.constraints.NotBlank

--- a/app-server/src/main/kotlin/org/hkurh/doky/password/impl/DefaultPasswordFacade.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/password/impl/DefaultPasswordFacade.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.password.impl
 
 import io.github.oshai.kotlinlogging.KotlinLogging

--- a/app-server/src/main/kotlin/org/hkurh/doky/password/impl/DefaultResetPasswordService.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/password/impl/DefaultResetPasswordService.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.password.impl
 
 import org.hkurh.doky.errorhandling.DokyInvalidTokenException

--- a/app-server/src/main/kotlin/org/hkurh/doky/password/impl/DefaultTokenService.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/password/impl/DefaultTokenService.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.password.impl
 
 import org.hkurh.doky.password.TokenService

--- a/app-server/src/main/kotlin/org/hkurh/doky/security/DokyUserDetails.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/security/DokyUserDetails.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.security
 
 import org.hkurh.doky.users.db.UserEntity

--- a/app-server/src/main/kotlin/org/hkurh/doky/security/JwtAuthorizationFilter.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/security/JwtAuthorizationFilter.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.security
 
 import io.github.oshai.kotlinlogging.KotlinLogging

--- a/app-server/src/main/kotlin/org/hkurh/doky/security/JwtProvider.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/security/JwtProvider.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.security
 
 import io.jsonwebtoken.Jwts

--- a/app-server/src/main/kotlin/org/hkurh/doky/security/SpringSecurityAuditorAware.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/security/SpringSecurityAuditorAware.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.security
 
 import org.hkurh.doky.users.db.UserEntity

--- a/app-server/src/main/kotlin/org/hkurh/doky/security/WebSecurityConfig.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/security/WebSecurityConfig.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.security
 
 import org.springframework.context.annotation.Bean

--- a/app-server/src/main/kotlin/org/hkurh/doky/users/UserFacade.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/users/UserFacade.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.users
 
 import org.hkurh.doky.users.api.UpdateUserRequest

--- a/app-server/src/main/kotlin/org/hkurh/doky/users/UserService.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/users/UserService.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.users
 
 import org.hkurh.doky.users.db.UserEntity

--- a/app-server/src/main/kotlin/org/hkurh/doky/users/api/UpdateUserRequest.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/users/api/UpdateUserRequest.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.users.api
 
 import jakarta.validation.constraints.NotBlank

--- a/app-server/src/main/kotlin/org/hkurh/doky/users/api/UserApi.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/users/api/UserApi.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.users.api
 
 import io.swagger.v3.oas.annotations.Operation

--- a/app-server/src/main/kotlin/org/hkurh/doky/users/api/UserController.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/users/api/UserController.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.users.api
 
 import org.hkurh.doky.users.UserFacade

--- a/app-server/src/main/kotlin/org/hkurh/doky/users/api/UserDto.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/users/api/UserDto.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.users.api
 
 import com.fasterxml.jackson.annotation.JsonIgnore

--- a/app-server/src/main/kotlin/org/hkurh/doky/users/impl/DefaultUserFacade.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/users/impl/DefaultUserFacade.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.users.impl
 
 import io.github.oshai.kotlinlogging.KotlinLogging

--- a/app-server/src/main/kotlin/org/hkurh/doky/users/impl/DefaultUserService.kt
+++ b/app-server/src/main/kotlin/org/hkurh/doky/users/impl/DefaultUserService.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.users.impl
 
 import io.github.oshai.kotlinlogging.KotlinLogging

--- a/app-server/src/test/kotlin/org/hkurh/doky/DokyUnitTest.kt
+++ b/app-server/src/test/kotlin/org/hkurh/doky/DokyUnitTest.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky
 
 import org.junit.jupiter.api.Tag

--- a/app-server/src/test/kotlin/org/hkurh/doky/authorization/AuthorizationUserControllerTest.kt
+++ b/app-server/src/test/kotlin/org/hkurh/doky/authorization/AuthorizationUserControllerTest.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.authorization
 
 import org.hkurh.doky.DokyUnitTest

--- a/app-server/src/test/kotlin/org/hkurh/doky/documents/impl/DefaultDocumentFacadeTest.kt
+++ b/app-server/src/test/kotlin/org/hkurh/doky/documents/impl/DefaultDocumentFacadeTest.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.documents.impl
 
 import org.hkurh.doky.DokyUnitTest

--- a/app-server/src/test/kotlin/org/hkurh/doky/filestorage/DefaultFileStorageServiceTest.kt
+++ b/app-server/src/test/kotlin/org/hkurh/doky/filestorage/DefaultFileStorageServiceTest.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.filestorage
 
 import org.hkurh.doky.DokyUnitTest

--- a/app-server/src/test/kotlin/org/hkurh/doky/kafka/KafkaEmailNotificationProducerServiceTest.kt
+++ b/app-server/src/test/kotlin/org/hkurh/doky/kafka/KafkaEmailNotificationProducerServiceTest.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.kafka
 
 import org.hkurh.doky.DokyUnitTest

--- a/app-server/src/test/kotlin/org/hkurh/doky/password/DefaultPasswordFacadeTest.kt
+++ b/app-server/src/test/kotlin/org/hkurh/doky/password/DefaultPasswordFacadeTest.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.password
 
 import org.hkurh.doky.DokyUnitTest

--- a/app-server/src/test/kotlin/org/hkurh/doky/password/DefaultResetPasswordServiceTest.kt
+++ b/app-server/src/test/kotlin/org/hkurh/doky/password/DefaultResetPasswordServiceTest.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.password
 
 import org.hkurh.doky.DokyUnitTest

--- a/app-server/src/test/kotlin/org/hkurh/doky/security/JwtAuthorizationFilterTest.kt
+++ b/app-server/src/test/kotlin/org/hkurh/doky/security/JwtAuthorizationFilterTest.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.security
 
 import jakarta.servlet.http.HttpServletResponse

--- a/app-server/src/test/kotlin/org/hkurh/doky/users/DefaultUserFacadeTest.kt
+++ b/app-server/src/test/kotlin/org/hkurh/doky/users/DefaultUserFacadeTest.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.users
 
 import org.hkurh.doky.DokyUnitTest

--- a/app-server/src/test/kotlin/org/hkurh/doky/users/DefaultUserServiceTest.kt
+++ b/app-server/src/test/kotlin/org/hkurh/doky/users/DefaultUserServiceTest.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.users
 
 import org.hkurh.doky.DokyUnitTest

--- a/cleanup-functions/src/main/kotlin/org/hkurh/doky/CleanupFunctionsApplication.kt
+++ b/cleanup-functions/src/main/kotlin/org/hkurh/doky/CleanupFunctionsApplication.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky
 
 import org.springframework.boot.autoconfigure.SpringBootApplication

--- a/cleanup-functions/src/main/kotlin/org/hkurh/doky/CleanupFunctionsConfig.kt
+++ b/cleanup-functions/src/main/kotlin/org/hkurh/doky/CleanupFunctionsConfig.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties

--- a/cleanup-functions/src/main/kotlin/org/hkurh/doky/functions/CleanupExpiredTokensHandler.kt
+++ b/cleanup-functions/src/main/kotlin/org/hkurh/doky/functions/CleanupExpiredTokensHandler.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.functions
 
 import com.microsoft.azure.functions.ExecutionContext

--- a/cleanup-functions/src/main/kotlin/org/hkurh/doky/tokens/DefaultExpiredTokensService.kt
+++ b/cleanup-functions/src/main/kotlin/org/hkurh/doky/tokens/DefaultExpiredTokensService.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.tokens
 
 import io.github.oshai.kotlinlogging.KotlinLogging

--- a/cleanup-functions/src/main/kotlin/org/hkurh/doky/tokens/ExpiredTokensService.kt
+++ b/cleanup-functions/src/main/kotlin/org/hkurh/doky/tokens/ExpiredTokensService.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.tokens
 
 interface ExpiredTokensService {

--- a/email-service/src/integrationTest/kotlin/org/hkurh/doky/DokyIntegrationTest.kt
+++ b/email-service/src/integrationTest/kotlin/org/hkurh/doky/DokyIntegrationTest.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky
 
 import org.junit.jupiter.api.Tag

--- a/email-service/src/integrationTest/kotlin/org/hkurh/doky/SmtpServerExtension.kt
+++ b/email-service/src/integrationTest/kotlin/org/hkurh/doky/SmtpServerExtension.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky
 
 import com.icegreen.greenmail.configuration.GreenMailConfiguration

--- a/email-service/src/integrationTest/kotlin/org/hkurh/doky/kafka/KafkaEmailNotificationConsumerServiceIntegrationTest.kt
+++ b/email-service/src/integrationTest/kotlin/org/hkurh/doky/kafka/KafkaEmailNotificationConsumerServiceIntegrationTest.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.kafka
 
 import com.icegreen.greenmail.util.GreenMail

--- a/email-service/src/main/kotlin/org/hkurh/doky/EmailServiceApplication.kt
+++ b/email-service/src/main/kotlin/org/hkurh/doky/EmailServiceApplication.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky
 
 import org.springframework.beans.factory.annotation.Value

--- a/email-service/src/main/kotlin/org/hkurh/doky/KafkaConsumerConfig.kt
+++ b/email-service/src/main/kotlin/org/hkurh/doky/KafkaConsumerConfig.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky
 
 import org.apache.kafka.clients.CommonClientConfigs

--- a/email-service/src/main/kotlin/org/hkurh/doky/email/EmailProperties.kt
+++ b/email-service/src/main/kotlin/org/hkurh/doky/email/EmailProperties.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.email
 
 import org.springframework.boot.context.properties.ConfigurationProperties

--- a/email-service/src/main/kotlin/org/hkurh/doky/email/EmailService.kt
+++ b/email-service/src/main/kotlin/org/hkurh/doky/email/EmailService.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.email
 
 import org.hkurh.doky.users.db.UserEntity

--- a/email-service/src/main/kotlin/org/hkurh/doky/email/impl/DefaultEmailService.kt
+++ b/email-service/src/main/kotlin/org/hkurh/doky/email/impl/DefaultEmailService.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.email.impl
 
 import io.github.oshai.kotlinlogging.KotlinLogging

--- a/email-service/src/main/kotlin/org/hkurh/doky/email/impl/SendgridEmailService.kt
+++ b/email-service/src/main/kotlin/org/hkurh/doky/email/impl/SendgridEmailService.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.email.impl
 
 import com.sendgrid.Method

--- a/email-service/src/main/kotlin/org/hkurh/doky/kafka/KafkaEmailNotificationConsumerService.kt
+++ b/email-service/src/main/kotlin/org/hkurh/doky/kafka/KafkaEmailNotificationConsumerService.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.kafka
 
 import io.github.oshai.kotlinlogging.KotlinLogging

--- a/email-service/src/main/kotlin/org/hkurh/doky/kafka/SendEmailMessage.kt
+++ b/email-service/src/main/kotlin/org/hkurh/doky/kafka/SendEmailMessage.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.kafka
 
 import com.fasterxml.jackson.annotation.JsonProperty

--- a/email-service/src/test/kotlin/org/hkurh/doky/DokyUnitTest.kt
+++ b/email-service/src/test/kotlin/org/hkurh/doky/DokyUnitTest.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky
 
 import org.junit.jupiter.api.Tag

--- a/email-service/src/test/kotlin/org/hkurh/doky/email/impl/DefaultEmailServiceTest.kt
+++ b/email-service/src/test/kotlin/org/hkurh/doky/email/impl/DefaultEmailServiceTest.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.email.impl
 
 import jakarta.mail.internet.MimeMessage

--- a/email-service/src/test/kotlin/org/hkurh/doky/email/impl/SendgridEmailServiceTest.kt
+++ b/email-service/src/test/kotlin/org/hkurh/doky/email/impl/SendgridEmailServiceTest.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.email.impl
 
 import com.sendgrid.helpers.mail.Mail

--- a/email-service/src/test/kotlin/org/hkurh/doky/kafka/KafkaEmailNotificationConsumerServiceTest.kt
+++ b/email-service/src/test/kotlin/org/hkurh/doky/kafka/KafkaEmailNotificationConsumerServiceTest.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.kafka
 
 import org.hkurh.doky.DokyUnitTest

--- a/indexer-service/src/integrationTest/kotlin/org/hkurh/doky/DokyIntegrationTest.kt
+++ b/indexer-service/src/integrationTest/kotlin/org/hkurh/doky/DokyIntegrationTest.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky
 
 import com.github.tomakehurst.wiremock.WireMockServer

--- a/indexer-service/src/integrationTest/kotlin/org/hkurh/doky/search/index/impl/DefaultIndexServiceIntegrationTest.kt
+++ b/indexer-service/src/integrationTest/kotlin/org/hkurh/doky/search/index/impl/DefaultIndexServiceIntegrationTest.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.search.index.impl
 
 import com.github.tomakehurst.wiremock.client.WireMock

--- a/indexer-service/src/main/kotlin/org/hkurh/doky/IndexerServiceApplication.kt
+++ b/indexer-service/src/main/kotlin/org/hkurh/doky/IndexerServiceApplication.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky
 
 import io.jsonwebtoken.SignatureAlgorithm

--- a/indexer-service/src/main/kotlin/org/hkurh/doky/JacksonConfig.kt
+++ b/indexer-service/src/main/kotlin/org/hkurh/doky/JacksonConfig.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky
 
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/indexer-service/src/main/kotlin/org/hkurh/doky/Mapper.kt
+++ b/indexer-service/src/main/kotlin/org/hkurh/doky/Mapper.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky
 
 import org.hkurh.doky.documents.db.DocumentEntity

--- a/indexer-service/src/main/kotlin/org/hkurh/doky/admin/SearchController.kt
+++ b/indexer-service/src/main/kotlin/org/hkurh/doky/admin/SearchController.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.admin
 
 import org.hkurh.doky.search.index.IndexService

--- a/indexer-service/src/main/kotlin/org/hkurh/doky/search/DocumentIndexData.kt
+++ b/indexer-service/src/main/kotlin/org/hkurh/doky/search/DocumentIndexData.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.search
 
 import com.fasterxml.jackson.annotation.JsonCreator

--- a/indexer-service/src/main/kotlin/org/hkurh/doky/search/index/IndexService.kt
+++ b/indexer-service/src/main/kotlin/org/hkurh/doky/search/index/IndexService.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.search.index
 
 /**

--- a/indexer-service/src/main/kotlin/org/hkurh/doky/search/index/impl/DefaultIndexService.kt
+++ b/indexer-service/src/main/kotlin/org/hkurh/doky/search/index/impl/DefaultIndexService.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.search.index.impl
 
 import com.azure.search.documents.SearchClient

--- a/indexer-service/src/main/kotlin/org/hkurh/doky/search/schedule/Scheduler.kt
+++ b/indexer-service/src/main/kotlin/org/hkurh/doky/search/schedule/Scheduler.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.search.schedule
 
 /**

--- a/indexer-service/src/main/kotlin/org/hkurh/doky/search/schedule/impl/DefaultScheduler.kt
+++ b/indexer-service/src/main/kotlin/org/hkurh/doky/search/schedule/impl/DefaultScheduler.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.search.schedule.impl
 
 import io.github.oshai.kotlinlogging.KotlinLogging

--- a/indexer-service/src/main/kotlin/org/hkurh/doky/security/DokyUserDetails.kt
+++ b/indexer-service/src/main/kotlin/org/hkurh/doky/security/DokyUserDetails.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.security
 
 import org.hkurh.doky.users.db.UserEntity

--- a/indexer-service/src/main/kotlin/org/hkurh/doky/security/JwtAuthorizationFilter.kt
+++ b/indexer-service/src/main/kotlin/org/hkurh/doky/security/JwtAuthorizationFilter.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.security
 
 import io.github.oshai.kotlinlogging.KotlinLogging

--- a/indexer-service/src/main/kotlin/org/hkurh/doky/security/JwtProvider.kt
+++ b/indexer-service/src/main/kotlin/org/hkurh/doky/security/JwtProvider.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.security
 
 import io.jsonwebtoken.Jwts

--- a/indexer-service/src/main/kotlin/org/hkurh/doky/security/SpringSecurityAuditorAware.kt
+++ b/indexer-service/src/main/kotlin/org/hkurh/doky/security/SpringSecurityAuditorAware.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.security
 
 import org.hkurh.doky.users.db.UserEntity

--- a/indexer-service/src/main/kotlin/org/hkurh/doky/security/WebSecurityConfig.kt
+++ b/indexer-service/src/main/kotlin/org/hkurh/doky/security/WebSecurityConfig.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.security
 
 import org.springframework.context.annotation.Bean

--- a/indexer-service/src/test/kotlin/org/hkurh/doky/DokyUnitTest.kt
+++ b/indexer-service/src/test/kotlin/org/hkurh/doky/DokyUnitTest.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky
 
 import org.junit.jupiter.api.Tag

--- a/persistence/src/main/kotlin/org/hkurh/doky/documents/db/DocumentEntity.kt
+++ b/persistence/src/main/kotlin/org/hkurh/doky/documents/db/DocumentEntity.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.documents.db
 
 import jakarta.persistence.Column

--- a/persistence/src/main/kotlin/org/hkurh/doky/documents/db/DocumentEntityRepository.kt
+++ b/persistence/src/main/kotlin/org/hkurh/doky/documents/db/DocumentEntityRepository.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.documents.db
 
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor

--- a/persistence/src/main/kotlin/org/hkurh/doky/documents/db/DownloadDocumentTokenEntity.kt
+++ b/persistence/src/main/kotlin/org/hkurh/doky/documents/db/DownloadDocumentTokenEntity.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.documents.db
 
 import jakarta.persistence.Column

--- a/persistence/src/main/kotlin/org/hkurh/doky/documents/db/DownloadDocumentTokenEntityRepository.kt
+++ b/persistence/src/main/kotlin/org/hkurh/doky/documents/db/DownloadDocumentTokenEntityRepository.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.documents.db
 
 import org.hkurh.doky.users.db.UserEntity

--- a/persistence/src/main/kotlin/org/hkurh/doky/password/db/ResetPasswordTokenEntity.kt
+++ b/persistence/src/main/kotlin/org/hkurh/doky/password/db/ResetPasswordTokenEntity.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.password.db
 
 import jakarta.persistence.Column

--- a/persistence/src/main/kotlin/org/hkurh/doky/password/db/ResetPasswordTokenEntityRepository.kt
+++ b/persistence/src/main/kotlin/org/hkurh/doky/password/db/ResetPasswordTokenEntityRepository.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.password.db
 
 import org.hkurh.doky.users.db.UserEntity

--- a/persistence/src/main/kotlin/org/hkurh/doky/security/UserAuthority.kt
+++ b/persistence/src/main/kotlin/org/hkurh/doky/security/UserAuthority.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.security
 
 enum class UserAuthority {

--- a/persistence/src/main/kotlin/org/hkurh/doky/users/db/AuthorityEntity.kt
+++ b/persistence/src/main/kotlin/org/hkurh/doky/users/db/AuthorityEntity.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.users.db
 
 import jakarta.persistence.Column

--- a/persistence/src/main/kotlin/org/hkurh/doky/users/db/AuthorityEntityRepository.kt
+++ b/persistence/src/main/kotlin/org/hkurh/doky/users/db/AuthorityEntityRepository.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.users.db
 
 import org.hkurh.doky.security.UserAuthority

--- a/persistence/src/main/kotlin/org/hkurh/doky/users/db/UserEntity.kt
+++ b/persistence/src/main/kotlin/org/hkurh/doky/users/db/UserEntity.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.users.db
 
 import jakarta.persistence.Column

--- a/persistence/src/main/kotlin/org/hkurh/doky/users/db/UserEntityRepository.kt
+++ b/persistence/src/main/kotlin/org/hkurh/doky/users/db/UserEntityRepository.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2005
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see [Hyperlink removed
+ * for security reasons]().
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 package org.hkurh.doky.users.db
 
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor


### PR DESCRIPTION
Add GPLv3 license headers to all project source files

Added GNU General Public License (GPLv3) headers to all relevant source and HTML files across the project. This ensures proper attribution and alignment with open-source licensing standards. The changes also include author information and project homepage links to improve traceability.