### PR TITLE
DOKY-205 Prevent duplicate email sends to customers

### DIFF
--- a/src/main/kotlin/org/hkurh/doky/Utils.kt
+++ b/src/main/kotlin/org/hkurh/doky/Utils.kt
@@ -31,10 +31,9 @@ fun String.mask(
         return maskChar.toString().repeat(this.length)
     }
     val maskLength = this.length - (startLength + endLength)
-    return """
-        |${this.substring(0, startLength)}
-        |${maskChar.toString().repeat(maskLength)}
-        |${this.substring(this.length - endLength)}""".trimMargin()
+    return "${this.substring(0, startLength)}${
+        maskChar.toString().repeat(maskLength)
+    }${this.substring(this.length - endLength)}"
 }
 
 fun String?.getExtension(): String {

--- a/src/main/kotlin/org/hkurh/doky/email/EmailService.kt
+++ b/src/main/kotlin/org/hkurh/doky/email/EmailService.kt
@@ -22,13 +22,16 @@ package org.hkurh.doky.email
 interface EmailService {
 
     /**
-     * Sends a reset password email to the user associated with the provided reset password token.
+     * Sends a password reset email to the user identified by the provided user ID.
      *
-     * @param resetPasswordTokenEntity The entity containing the reset password token details,
-     * including the user information, token, and expiration date.
+     * @param userId The ID of the user to whom the password reset email will be sent.
      */
     fun sendResetPasswordEmail(userId: Long)
 
-
+    /**
+     * Sends a registration confirmation email to the user identified by the provided user ID.
+     *
+     * @param userId The ID of the user to whom the registration email will be sent.
+     */
     fun sendRegistrationEmail(userId: Long)
 }

--- a/src/main/kotlin/org/hkurh/doky/email/EmailService.kt
+++ b/src/main/kotlin/org/hkurh/doky/email/EmailService.kt
@@ -19,8 +19,6 @@
 
 package org.hkurh.doky.email
 
-import org.hkurh.doky.password.db.ResetPasswordTokenEntity
-
 interface EmailService {
 
     /**
@@ -29,5 +27,8 @@ interface EmailService {
      * @param resetPasswordTokenEntity The entity containing the reset password token details,
      * including the user information, token, and expiration date.
      */
-    fun sendResetPasswordEmail(resetPasswordTokenEntity: ResetPasswordTokenEntity)
+    fun sendResetPasswordEmail(userId: Long)
+
+
+    fun sendRegistrationEmail(userId: Long)
 }

--- a/src/main/kotlin/org/hkurh/doky/errorhandling/Exceptions.kt
+++ b/src/main/kotlin/org/hkurh/doky/errorhandling/Exceptions.kt
@@ -25,3 +25,4 @@ class DokyAuthenticationException(message: String) : AuthenticationException(mes
 class DokyNotFoundException(message: String) : RuntimeException(message)
 class DokyRegistrationException(message: String) : RuntimeException(message)
 class DokyInvalidTokenException(message: String) : RuntimeException(message)
+class DokyEmailException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/org/hkurh/doky/kafka/KafkaEmailNotificationConsumerService.kt
+++ b/src/main/kotlin/org/hkurh/doky/kafka/KafkaEmailNotificationConsumerService.kt
@@ -21,17 +21,13 @@ package org.hkurh.doky.kafka
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.hkurh.doky.email.EmailService
-import org.hkurh.doky.password.db.ResetPasswordTokenEntityRepository
-import org.hkurh.doky.users.db.UserEntityRepository
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.messaging.handler.annotation.Payload
 import org.springframework.stereotype.Service
 
 @Service
 class KafkaEmailNotificationConsumerService(
-    private val userEntityRepository: UserEntityRepository,
-    private val emailService: EmailService,
-    private val resetPasswordTokenEntityRepository: ResetPasswordTokenEntityRepository
+    private val emailService: EmailService
 ) {
 
     private val log = KotlinLogging.logger {}
@@ -45,17 +41,13 @@ class KafkaEmailNotificationConsumerService(
         concurrency = "\${doky.kafka.emails.concurrency}"
     )
     fun listen(@Payload message: SendEmailMessage) {
-        try {
-            log.debug { "Received message: [$message]" }
-            message.userId.let {
-                when (message.emailType) {
-                    EmailType.REGISTRATION -> emailService.sendRegistrationEmail(message.userId!!)
-                    EmailType.RESET_PASSWORD -> emailService.sendResetPasswordEmail(message.userId!!)
-                    null -> log.warn { "No email type specified" }
-                }
+        log.debug { "Received message: [$message]" }
+        message.userId.let {
+            when (message.emailType) {
+                EmailType.REGISTRATION -> emailService.sendRegistrationEmail(message.userId!!)
+                EmailType.RESET_PASSWORD -> emailService.sendResetPasswordEmail(message.userId!!)
+                null -> log.warn { "No email type specified" }
             }
-        } catch (e: Exception) {
-            log.error(e) { "Error processing message: [$message]" }
         }
     }
 }

--- a/src/main/kotlin/org/hkurh/doky/password/db/ResetPasswordTokenEntityRepository.kt
+++ b/src/main/kotlin/org/hkurh/doky/password/db/ResetPasswordTokenEntityRepository.kt
@@ -41,8 +41,8 @@ interface ResetPasswordTokenEntityRepository :
     @Query(
         """
         SELECT r FROM ResetPasswordTokenEntity r 
-        WHERE r.user.id = :userId AND r.expirationDate > CURRENT_TIMESTAMP AND r.sentEmail = false
+        WHERE r.user.id = :userId AND r.expirationDate > CURRENT_TIMESTAMP
     """
     )
-    fun findValidUnsentTokensByUserId(userId: Long): List<ResetPasswordTokenEntity>
+    fun findValidTokensByUserId(userId: Long): List<ResetPasswordTokenEntity>
 }

--- a/src/main/kotlin/org/hkurh/doky/users/db/UserEntity.kt
+++ b/src/main/kotlin/org/hkurh/doky/users/db/UserEntity.kt
@@ -60,4 +60,7 @@ class UserEntity {
         inverseJoinColumns = [JoinColumn(name = "authority_id", referencedColumnName = "id")]
     )
     var authorities: MutableSet<AuthorityEntity> = HashSet()
+
+    @Column(name = "sent_registration_email", nullable = false)
+    var sentRegistrationEmail: Boolean = false
 }

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -98,7 +98,7 @@
     {
       "name": "doky.kafka.emails.consumer.id",
       "type": "java.lang.String",
-      "description": "Kafka consumer is for emails topic."
+      "description": "Kafka consumer id for emails topic."
     },
     {
       "name": "doky.kafka.emails.consumer.autostart",

--- a/src/main/resources/migration/mysql/V1_9__add_flag_sent_registration_email.sql
+++ b/src/main/resources/migration/mysql/V1_9__add_flag_sent_registration_email.sql
@@ -1,0 +1,8 @@
+ALTER TABLE users
+    ADD COLUMN sent_registration_email BIT(1) NULL;
+
+UPDATE users
+SET sent_registration_email = b'1';
+
+ALTER TABLE users
+    MODIFY COLUMN sent_registration_email BIT(1) NOT NULL DEFAULT b'0';

--- a/src/main/resources/migration/sqlserver/V1_9__add_flag_sent_registration_email.sql
+++ b/src/main/resources/migration/sqlserver/V1_9__add_flag_sent_registration_email.sql
@@ -1,0 +1,16 @@
+ALTER TABLE users
+    ADD sent_registration_email bit
+GO
+
+UPDATE users
+    SET sent_registration_email = 1
+    WHERE sent_registration_email IS NULL
+GO
+
+ALTER TABLE users
+    ADD DEFAULT 0 FOR sent_registration_email
+GO
+
+ALTER TABLE users
+    ALTER COLUMN sent_registration_email bit NOT NULL
+GO

--- a/src/test/kotlin/org/hkurh/doky/email/impl/TransactionalEmailServiceTest.kt
+++ b/src/test/kotlin/org/hkurh/doky/email/impl/TransactionalEmailServiceTest.kt
@@ -1,0 +1,186 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2025
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
+
+package org.hkurh.doky.email.impl
+
+import org.hkurh.doky.DokyUnitTest
+import org.hkurh.doky.email.EmailSender
+import org.hkurh.doky.password.db.ResetPasswordTokenEntity
+import org.hkurh.doky.password.db.ResetPasswordTokenEntityRepository
+import org.hkurh.doky.users.db.UserEntity
+import org.hkurh.doky.users.db.UserEntityRepository
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import java.util.Optional.empty
+import java.util.Optional.ofNullable
+
+@DisplayName("TransactionalEmailService unit test")
+class TransactionalEmailServiceTest : DokyUnitTest {
+
+    private val resetPasswordTokenEntityRepository: ResetPasswordTokenEntityRepository = mock()
+    private val userEntityRepository: UserEntityRepository = mock()
+    private val emailSender: EmailSender = mock()
+
+    private val emailService = TransactionalEmailService(
+        resetPasswordTokenEntityRepository,
+        userEntityRepository,
+        emailSender
+    )
+
+    @Test
+    @DisplayName("Should send registration confirmation email if it is not sent")
+    fun shouldSendRegistrationConfirmationEmail_ifItIsNotSent() {
+        // given
+        val existingUserId = 16L
+        val user = createUser(existingUserId)
+        whenever(userEntityRepository.findById(existingUserId)).thenReturn(ofNullable(user))
+
+        // when
+        emailService.sendRegistrationEmail(existingUserId)
+
+        // then
+        verify(emailSender).sendRegistrationConfirmationEmail(user)
+        argumentCaptor<UserEntity> {
+            verify(userEntityRepository).save(capture())
+            val captured = firstValue
+            assertAll(
+                { assertEquals(user.id, captured.id) },
+                { assertTrue(captured.sentRegistrationEmail) }
+            )
+        }
+    }
+
+    @Test
+    @DisplayName("Should not send registration confirmation email if it is sent")
+    fun shouldNotSendRegistrationConfirmationEmail_ifItIsSent() {
+        // given
+        val existingUserId = 17L
+        val user = createUser(existingUserId, true)
+        whenever(userEntityRepository.findById(existingUserId)).thenReturn(ofNullable(user))
+
+        // when
+        emailService.sendRegistrationEmail(existingUserId)
+
+        // then
+        verifyNoInteractions(emailSender)
+        verify(userEntityRepository, times(0)).save(any())
+    }
+
+    @Test
+    @DisplayName("Should not send registration confirmation email if user not found")
+    fun shouldNotSendRegistrationConfirmationEmail_ifUserNotFound() {
+        // given
+        val nonExistingUserId = 18L
+        whenever(userEntityRepository.findById(nonExistingUserId)).thenReturn(empty())
+
+        // when
+        emailService.sendRegistrationEmail(nonExistingUserId)
+
+        // then
+        verifyNoInteractions(emailSender)
+        verify(userEntityRepository, times(0)).save(any())
+    }
+
+    @Test
+    @DisplayName("Should send reset password email if it is not sent")
+    fun shouldSendResetPasswordEmail_ifItIsNotSent() {
+        // given
+        val userId = 19L
+        val token = "token"
+        val user = createUser(userId)
+        val resetToken = createResetToken(user, token)
+        whenever(resetPasswordTokenEntityRepository.findValidTokensByUserId(userId)).thenReturn(listOf(resetToken))
+
+        // when
+        emailService.sendResetPasswordEmail(userId)
+
+        // then
+        verify(emailSender).sendRestorePasswordEmail(user, token)
+        argumentCaptor<ResetPasswordTokenEntity> {
+            verify(resetPasswordTokenEntityRepository).save(capture())
+            val captured = firstValue
+            assertAll(
+                { assertEquals(user.id, captured.user.id) },
+                { assertEquals(user.uid, captured.user.uid) },
+                { assertEquals(token, captured.token) },
+                { assertTrue(captured.sentEmail) }
+            )
+        }
+    }
+
+    @Test
+    @DisplayName("Should not send reset password email if it is sent")
+    fun shouldNotSendResetPasswordEmail_ifItIsSent() {
+        // given
+        val userId = 26L
+        val token = "token"
+        val user = createUser(userId)
+        val resetToken = createResetToken(user, token, true)
+        whenever(resetPasswordTokenEntityRepository.findValidTokensByUserId(userId)).thenReturn(listOf(resetToken))
+
+        // when
+        emailService.sendResetPasswordEmail(userId)
+
+        // then
+        verifyNoInteractions(emailSender)
+        verify(resetPasswordTokenEntityRepository, times(0)).save(any())
+    }
+
+    @Test
+    @DisplayName("Should not send reset password email if no valid tokens found")
+    fun shouldNotSendResetPasswordEmail_ifNoValidTokensFound() {
+        // given
+        val userId = 27L
+        whenever(resetPasswordTokenEntityRepository.findValidTokensByUserId(userId)).thenReturn(emptyList())
+
+        // when
+        emailService.sendResetPasswordEmail(userId)
+
+        // then
+        verifyNoInteractions(emailSender)
+        verify(resetPasswordTokenEntityRepository, times(0)).save(any())
+    }
+
+    private fun createUser(id: Long, sent: Boolean = false): UserEntity {
+        return UserEntity().also {
+            it.id = id
+            it.uid = "test@mail.com"
+            it.sentRegistrationEmail = sent
+        }
+    }
+
+    private fun createResetToken(user: UserEntity, token: String, sent: Boolean = false): ResetPasswordTokenEntity {
+        return ResetPasswordTokenEntity().also {
+            it.user = user
+            it.token = token
+            it.sentEmail = sent
+        }
+    }
+}

--- a/src/test/kotlin/org/hkurh/doky/kafka/KafkaEmailNotificationConsumerServiceTest.kt
+++ b/src/test/kotlin/org/hkurh/doky/kafka/KafkaEmailNotificationConsumerServiceTest.kt
@@ -20,36 +20,20 @@
 package org.hkurh.doky.kafka
 
 import org.hkurh.doky.DokyUnitTest
-import org.hkurh.doky.email.EmailSender
 import org.hkurh.doky.email.EmailService
-import org.hkurh.doky.password.db.ResetPasswordTokenEntity
-import org.hkurh.doky.password.db.ResetPasswordTokenEntityRepository
 import org.hkurh.doky.users.db.UserEntity
-import org.hkurh.doky.users.db.UserEntityRepository
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.times
-import org.mockito.kotlin.whenever
-import java.util.*
 
 
 @DisplayName("KafkaEmailNotificationConsumerService unit test")
 class KafkaEmailNotificationConsumerServiceTest : DokyUnitTest {
 
-    private val userEntityRepository: UserEntityRepository = mock()
     private val emailService: EmailService = mock()
-    private val resetPasswordTokenEntityRepository: ResetPasswordTokenEntityRepository = mock()
-    private val emailSender: EmailSender = mock()
 
-    private val service =
-        KafkaEmailNotificationConsumerService(
-            userEntityRepository = userEntityRepository,
-            resetPasswordTokenEntityRepository = resetPasswordTokenEntityRepository,
-            emailService = emailService,
-            emailSender = emailSender
-        )
+    private val service = KafkaEmailNotificationConsumerService(emailService)
 
 
     @Test
@@ -58,7 +42,6 @@ class KafkaEmailNotificationConsumerServiceTest : DokyUnitTest {
         // given
         val existingUserId = 16L
         val user = createUser(existingUserId)
-        whenever(userEntityRepository.findById(existingUserId)).thenReturn(Optional.ofNullable(user))
 
         val message = SendEmailMessage().apply {
             userId = existingUserId
@@ -69,7 +52,7 @@ class KafkaEmailNotificationConsumerServiceTest : DokyUnitTest {
         service.listen(message)
 
         // then
-        verify(emailSender, times(1)).sendRegistrationConfirmationEmail(user)
+        verify(emailService).sendRegistrationEmail(user.id)
     }
 
     @Test
@@ -77,15 +60,15 @@ class KafkaEmailNotificationConsumerServiceTest : DokyUnitTest {
     fun shouldSendResetPasswordEmail() {
         // given
         val existingUserId = 14L
-        val token = "<TOKEN>"
+//        val token = "<TOKEN>"
         val user = createUser(existingUserId)
-        val resetToken = createResetToken(user, token)
-        whenever(userEntityRepository.findById(existingUserId)).thenReturn(Optional.ofNullable(user))
-        whenever(resetPasswordTokenEntityRepository.findValidUnsentTokensByUserId(existingUserId)).thenReturn(
-            listOf(
-                resetToken
-            )
-        )
+//        val resetToken = createResetToken(user, token)
+//        whenever(userEntityRepository.findById(existingUserId)).thenReturn(Optional.ofNullable(user))
+//        whenever(resetPasswordTokenEntityRepository.findValidTokensByUserId(existingUserId)).thenReturn(
+//            listOf(
+//                resetToken
+//            )
+//        )
 
         val message = SendEmailMessage().apply {
             userId = existingUserId
@@ -96,20 +79,13 @@ class KafkaEmailNotificationConsumerServiceTest : DokyUnitTest {
         service.listen(message)
 
         // then
-        verify(emailService, times(1)).sendResetPasswordEmail(resetToken)
+        verify(emailService).sendResetPasswordEmail(user.id)
     }
 
     private fun createUser(id: Long): UserEntity {
         return UserEntity().apply {
             this.id = id
             uid = "test@mail.com"
-        }
-    }
-
-    private fun createResetToken(user: UserEntity, token: String): ResetPasswordTokenEntity {
-        return ResetPasswordTokenEntity().apply {
-            this.user = user
-            this.token = token
         }
     }
 }


### PR DESCRIPTION
### Summary
This pull request addresses the issue of duplicate email sends to customers by improving email handling logic, adding safeguards, and refactoring related services.

### Changes
- Refactored the `SendgridEmailSender` for better exception handling and meaningful logging.
- Simplified `KafkaEmailNotificationConsumerService` while delegating email operations to `EmailService`.
- Updated `EmailService` interface to split responsibilities into `sendRegistrationEmail` and `sendResetPasswordEmail`.
- Introduced a new `sent_registration_email` column in the `users` table to track registration email status.
- Modified repository queries and entity classes to reflect the new email-tracking logic.
- Added `DokyEmailException` for consistent email-related error handling across services.
- Enhanced unit test coverage for `TransactionalEmailService` to ensure reliable behavior under diverse scenarios.
- Adjusted Kafka consumer implementation to align with the revised email logic.

### Further Notes
- Unit tests have been included to verify changes and ensure no regressions occur.
- Database schema updates require migration to include the new `sent_registration_email` column.