### PR TITLE
DOKY-244 Update copyright header

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/cypress.config.js
+++ b/doky-front/cypress.config.js
@@ -1,3 +1,22 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2022-2025
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 const {defineConfig} = require("cypress");
 const https = require("https");
 

--- a/doky-front/cypress/e2e/login.cy.js
+++ b/doky-front/cypress/e2e/login.cy.js
@@ -1,3 +1,22 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2022-2025
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 describe('doky login', () => {
 
   beforeEach(() => {

--- a/doky-front/cypress/support/commands.js
+++ b/doky-front/cypress/support/commands.js
@@ -1,3 +1,22 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2022-2025
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 // ***********************************************
 // This example commands.js shows you how to
 // create various custom commands and overwrite

--- a/doky-front/cypress/support/e2e.js
+++ b/doky-front/cypress/support/e2e.js
@@ -1,3 +1,22 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2022-2025
+ *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
 // ***********************************************************
 // This example support/e2e.js is processed and
 // loaded automatically before your test files.

--- a/doky-front/src/App.jsx
+++ b/doky-front/src/App.jsx
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/api/config.auto.js
+++ b/doky-front/src/api/config.auto.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/api/config.local.js
+++ b/doky-front/src/api/config.local.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/api/config.remote.js
+++ b/doky-front/src/api/config.remote.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/api/documents.js
+++ b/doky-front/src/api/documents.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/api/request.js
+++ b/doky-front/src/api/request.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/api/users.js
+++ b/doky-front/src/api/users.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/components/AlertError.jsx
+++ b/doky-front/src/components/AlertError.jsx
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/components/BasePage.jsx
+++ b/doky-front/src/components/BasePage.jsx
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/components/Logo/Logo.jsx
+++ b/doky-front/src/components/Logo/Logo.jsx
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/components/Logo/index.js
+++ b/doky-front/src/components/Logo/index.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/components/MainPage.jsx
+++ b/doky-front/src/components/MainPage.jsx
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/components/Toasts/Toasts.hooks.js
+++ b/doky-front/src/components/Toasts/Toasts.hooks.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/components/Toasts/Toasts.jsx
+++ b/doky-front/src/components/Toasts/Toasts.jsx
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/components/Toasts/ToastsContext.js
+++ b/doky-front/src/components/Toasts/ToastsContext.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/components/Toasts/index.js
+++ b/doky-front/src/components/Toasts/index.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/components/formComponents/FileUploader.jsx
+++ b/doky-front/src/components/formComponents/FileUploader.jsx
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/components/formComponents/FormInput.jsx
+++ b/doky-front/src/components/formComponents/FormInput.jsx
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/components/formComponents/HorizontalFormInput.jsx
+++ b/doky-front/src/components/formComponents/HorizontalFormInput.jsx
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/components/formComponents/HorizontalFormText.jsx
+++ b/doky-front/src/components/formComponents/HorizontalFormText.jsx
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/components/index.js
+++ b/doky-front/src/components/index.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/hooks/useForm.js
+++ b/doky-front/src/hooks/useForm.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/hooks/useFormData.js
+++ b/doky-front/src/hooks/useFormData.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/hooks/useMutation.js
+++ b/doky-front/src/hooks/useMutation.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/hooks/useQuery.js
+++ b/doky-front/src/hooks/useQuery.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/hooks/useUser.js
+++ b/doky-front/src/hooks/useUser.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/index.html
+++ b/doky-front/src/index.html
@@ -1,7 +1,7 @@
 <!--
   ~ This file is part of the Doky Project.
   ~
-  ~ Copyright (C) 2005
+  ~ Copyright (C) 2022-2025
   ~  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
   ~  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
   ~

--- a/doky-front/src/index.js
+++ b/doky-front/src/index.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/index.scss
+++ b/doky-front/src/index.scss
@@ -1,7 +1,7 @@
 /*!
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/pages/Documents/CreateDocumentForm/CreateDocumentForm.jsx
+++ b/doky-front/src/pages/Documents/CreateDocumentForm/CreateDocumentForm.jsx
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/pages/Documents/CreateDocumentForm/index.js
+++ b/doky-front/src/pages/Documents/CreateDocumentForm/index.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/pages/Documents/CreateDocumentPage.jsx
+++ b/doky-front/src/pages/Documents/CreateDocumentPage.jsx
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/pages/Documents/Documents.jsx
+++ b/doky-front/src/pages/Documents/Documents.jsx
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/pages/Documents/EditDocumentForm/EditDocumentForm.jsx
+++ b/doky-front/src/pages/Documents/EditDocumentForm/EditDocumentForm.jsx
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/pages/Documents/EditDocumentForm/index.js
+++ b/doky-front/src/pages/Documents/EditDocumentForm/index.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/pages/Documents/EditDocumentPage.jsx
+++ b/doky-front/src/pages/Documents/EditDocumentPage.jsx
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/pages/Documents/index.js
+++ b/doky-front/src/pages/Documents/index.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/pages/Home/Home.jsx
+++ b/doky-front/src/pages/Home/Home.jsx
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/pages/Home/index.js
+++ b/doky-front/src/pages/Home/index.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/pages/Login/Login.jsx
+++ b/doky-front/src/pages/Login/Login.jsx
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/pages/Login/index.js
+++ b/doky-front/src/pages/Login/index.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/pages/Login/useLogin.js
+++ b/doky-front/src/pages/Login/useLogin.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/pages/NotFoundPage.jsx
+++ b/doky-front/src/pages/NotFoundPage.jsx
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/pages/Register/Register.jsx
+++ b/doky-front/src/pages/Register/Register.jsx
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/pages/Register/index.js
+++ b/doky-front/src/pages/Register/index.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/pages/Register/useRegister.js
+++ b/doky-front/src/pages/Register/useRegister.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/pages/ResetPassword/ResetPassword.jsx
+++ b/doky-front/src/pages/ResetPassword/ResetPassword.jsx
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/pages/ResetPassword/index.js
+++ b/doky-front/src/pages/ResetPassword/index.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/pages/ResetPassword/useRequestResetPassword.js
+++ b/doky-front/src/pages/ResetPassword/useRequestResetPassword.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/pages/UpdatePassword/UpdatePassword.jsx
+++ b/doky-front/src/pages/UpdatePassword/UpdatePassword.jsx
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/pages/UpdatePassword/index.js
+++ b/doky-front/src/pages/UpdatePassword/index.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/pages/UpdatePassword/useUpdatePassword.js
+++ b/doky-front/src/pages/UpdatePassword/useUpdatePassword.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/pages/UserProfile/EditUserProfileForm/EditUserProfileForm.jsx
+++ b/doky-front/src/pages/UserProfile/EditUserProfileForm/EditUserProfileForm.jsx
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/pages/UserProfile/EditUserProfileForm/index.js
+++ b/doky-front/src/pages/UserProfile/EditUserProfileForm/index.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/pages/UserProfile/UserProfile.jsx
+++ b/doky-front/src/pages/UserProfile/UserProfile.jsx
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/pages/UserProfile/index.js
+++ b/doky-front/src/pages/UserProfile/index.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/routing/index.js
+++ b/doky-front/src/routing/index.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/routing/loaders.js
+++ b/doky-front/src/routing/loaders.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/routing/router.js
+++ b/doky-front/src/routing/router.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/routing/routes.js
+++ b/doky-front/src/routing/routes.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/services/save-file.js
+++ b/doky-front/src/services/save-file.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/services/storage.js
+++ b/doky-front/src/services/storage.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/src/utils.js
+++ b/doky-front/src/utils.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/doky-front/webpack.config.js
+++ b/doky-front/webpack.config.js
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 #
 # This file is part of the Doky Project.
 #
-# Copyright (C) 2005
+# Copyright (C) 2022-2025
 #  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
 #  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
 #

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/apiTest/kotlin/org/hkurh/doky/DocumentSpec.kt
+++ b/src/apiTest/kotlin/org/hkurh/doky/DocumentSpec.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/apiTest/kotlin/org/hkurh/doky/EmbeddedKafkaConsumerConfig.kt
+++ b/src/apiTest/kotlin/org/hkurh/doky/EmbeddedKafkaConsumerConfig.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/apiTest/kotlin/org/hkurh/doky/LoginSpec.kt
+++ b/src/apiTest/kotlin/org/hkurh/doky/LoginSpec.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/apiTest/kotlin/org/hkurh/doky/PasswordSpec.kt
+++ b/src/apiTest/kotlin/org/hkurh/doky/PasswordSpec.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/apiTest/kotlin/org/hkurh/doky/RegistrationSpec.kt
+++ b/src/apiTest/kotlin/org/hkurh/doky/RegistrationSpec.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/apiTest/kotlin/org/hkurh/doky/RestSpec.kt
+++ b/src/apiTest/kotlin/org/hkurh/doky/RestSpec.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/apiTest/kotlin/org/hkurh/doky/UserSpec.kt
+++ b/src/apiTest/kotlin/org/hkurh/doky/UserSpec.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/integrationTest/kotlin/org/hkurh/doky/DokyIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/hkurh/doky/DokyIntegrationTest.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/integrationTest/kotlin/org/hkurh/doky/EmbeddedKafkaConsumerConfig.kt
+++ b/src/integrationTest/kotlin/org/hkurh/doky/EmbeddedKafkaConsumerConfig.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/integrationTest/kotlin/org/hkurh/doky/SmtpServerExtension.kt
+++ b/src/integrationTest/kotlin/org/hkurh/doky/SmtpServerExtension.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/integrationTest/kotlin/org/hkurh/doky/kafka/KafkaEmailNotificationConsumerServiceIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/hkurh/doky/kafka/KafkaEmailNotificationConsumerServiceIntegrationTest.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/integrationTest/kotlin/org/hkurh/doky/password/impl/DefaultPasswordFacadeIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/hkurh/doky/password/impl/DefaultPasswordFacadeIntegrationTest.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/integrationTest/kotlin/org/hkurh/doky/search/index/impl/DefaultIndexServiceIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/hkurh/doky/search/index/impl/DefaultIndexServiceIntegrationTest.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/integrationTest/kotlin/org/hkurh/doky/users/DefaultUserServiceIntegrationTest.kt
+++ b/src/integrationTest/kotlin/org/hkurh/doky/users/DefaultUserServiceIntegrationTest.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/DokyApi.kt
+++ b/src/main/kotlin/org/hkurh/doky/DokyApi.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/DokyApplication.kt
+++ b/src/main/kotlin/org/hkurh/doky/DokyApplication.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/DokyController.kt
+++ b/src/main/kotlin/org/hkurh/doky/DokyController.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/DokyMapper.kt
+++ b/src/main/kotlin/org/hkurh/doky/DokyMapper.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/Utils.kt
+++ b/src/main/kotlin/org/hkurh/doky/Utils.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/admin/SearchController.kt
+++ b/src/main/kotlin/org/hkurh/doky/admin/SearchController.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/authorization/AuthenticationRequest.kt
+++ b/src/main/kotlin/org/hkurh/doky/authorization/AuthenticationRequest.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/authorization/AuthenticationResponse.kt
+++ b/src/main/kotlin/org/hkurh/doky/authorization/AuthenticationResponse.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/authorization/AuthorizationUserApi.kt
+++ b/src/main/kotlin/org/hkurh/doky/authorization/AuthorizationUserApi.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/authorization/AuthorizationUserController.kt
+++ b/src/main/kotlin/org/hkurh/doky/authorization/AuthorizationUserController.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/config/AiSearchConfig.kt
+++ b/src/main/kotlin/org/hkurh/doky/config/AiSearchConfig.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/config/ApiDocumentationConfig.kt
+++ b/src/main/kotlin/org/hkurh/doky/config/ApiDocumentationConfig.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/config/JacksonConfig.kt
+++ b/src/main/kotlin/org/hkurh/doky/config/JacksonConfig.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/config/KafkaConsumerConfig.kt
+++ b/src/main/kotlin/org/hkurh/doky/config/KafkaConsumerConfig.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/config/KafkaProducerConfig.kt
+++ b/src/main/kotlin/org/hkurh/doky/config/KafkaProducerConfig.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/config/WebSecurityConfig.kt
+++ b/src/main/kotlin/org/hkurh/doky/config/WebSecurityConfig.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/documents/DocumentFacade.kt
+++ b/src/main/kotlin/org/hkurh/doky/documents/DocumentFacade.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/documents/DocumentService.kt
+++ b/src/main/kotlin/org/hkurh/doky/documents/DocumentService.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/documents/DownloadTokenService.kt
+++ b/src/main/kotlin/org/hkurh/doky/documents/DownloadTokenService.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/documents/api/DocumentApi.kt
+++ b/src/main/kotlin/org/hkurh/doky/documents/api/DocumentApi.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/documents/api/DocumentController.kt
+++ b/src/main/kotlin/org/hkurh/doky/documents/api/DocumentController.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *
@@ -27,7 +27,13 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder
 import java.io.IOException

--- a/src/main/kotlin/org/hkurh/doky/documents/api/DocumentRequest.kt
+++ b/src/main/kotlin/org/hkurh/doky/documents/api/DocumentRequest.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/documents/api/DocumentResponse.kt
+++ b/src/main/kotlin/org/hkurh/doky/documents/api/DocumentResponse.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/documents/api/DownloadFileRequest.kt
+++ b/src/main/kotlin/org/hkurh/doky/documents/api/DownloadFileRequest.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/documents/api/DownloadTokenResponse.kt
+++ b/src/main/kotlin/org/hkurh/doky/documents/api/DownloadTokenResponse.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/documents/db/DocumentEntity.kt
+++ b/src/main/kotlin/org/hkurh/doky/documents/db/DocumentEntity.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/documents/db/DocumentEntityRepository.kt
+++ b/src/main/kotlin/org/hkurh/doky/documents/db/DocumentEntityRepository.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/documents/db/DownloadDocumentTokenEntity.kt
+++ b/src/main/kotlin/org/hkurh/doky/documents/db/DownloadDocumentTokenEntity.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/documents/db/DownloadDocumentTokenEntityRepository.kt
+++ b/src/main/kotlin/org/hkurh/doky/documents/db/DownloadDocumentTokenEntityRepository.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/documents/impl/DefaultDocumentFacade.kt
+++ b/src/main/kotlin/org/hkurh/doky/documents/impl/DefaultDocumentFacade.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/documents/impl/DefaultDocumentService.kt
+++ b/src/main/kotlin/org/hkurh/doky/documents/impl/DefaultDocumentService.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/documents/impl/DefaultDownloadTokenService.kt
+++ b/src/main/kotlin/org/hkurh/doky/documents/impl/DefaultDownloadTokenService.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/email/EmailProperties.kt
+++ b/src/main/kotlin/org/hkurh/doky/email/EmailProperties.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/email/EmailSender.kt
+++ b/src/main/kotlin/org/hkurh/doky/email/EmailSender.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/email/EmailService.kt
+++ b/src/main/kotlin/org/hkurh/doky/email/EmailService.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/email/impl/SendgridEmailSender.kt
+++ b/src/main/kotlin/org/hkurh/doky/email/impl/SendgridEmailSender.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/email/impl/SmtpEmailSender.kt
+++ b/src/main/kotlin/org/hkurh/doky/email/impl/SmtpEmailSender.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/email/impl/TransactionalEmailService.kt
+++ b/src/main/kotlin/org/hkurh/doky/email/impl/TransactionalEmailService.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/errorhandling/DokyControllerAdvice.kt
+++ b/src/main/kotlin/org/hkurh/doky/errorhandling/DokyControllerAdvice.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/errorhandling/ErrorResponses.kt
+++ b/src/main/kotlin/org/hkurh/doky/errorhandling/ErrorResponses.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/errorhandling/Exceptions.kt
+++ b/src/main/kotlin/org/hkurh/doky/errorhandling/Exceptions.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/filestorage/FileStorage.kt
+++ b/src/main/kotlin/org/hkurh/doky/filestorage/FileStorage.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/filestorage/FileStorageService.kt
+++ b/src/main/kotlin/org/hkurh/doky/filestorage/FileStorageService.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/filestorage/impl/DefaultFileStorageService.kt
+++ b/src/main/kotlin/org/hkurh/doky/filestorage/impl/DefaultFileStorageService.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/filestorage/impl/DokyAzureBlobStorage.kt
+++ b/src/main/kotlin/org/hkurh/doky/filestorage/impl/DokyAzureBlobStorage.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/filestorage/impl/DokyLocalFilesystemStorage.kt
+++ b/src/main/kotlin/org/hkurh/doky/filestorage/impl/DokyLocalFilesystemStorage.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/kafka/KafkaEmailNotificationConsumerService.kt
+++ b/src/main/kotlin/org/hkurh/doky/kafka/KafkaEmailNotificationConsumerService.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/kafka/KafkaEmailNotificationProducerService.kt
+++ b/src/main/kotlin/org/hkurh/doky/kafka/KafkaEmailNotificationProducerService.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/kafka/SendEmailMessage.kt
+++ b/src/main/kotlin/org/hkurh/doky/kafka/SendEmailMessage.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/maintenance/schedule/Scheduler.kt
+++ b/src/main/kotlin/org/hkurh/doky/maintenance/schedule/Scheduler.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/maintenance/schedule/impl/DefaultScheduler.kt
+++ b/src/main/kotlin/org/hkurh/doky/maintenance/schedule/impl/DefaultScheduler.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/password/PasswordFacade.kt
+++ b/src/main/kotlin/org/hkurh/doky/password/PasswordFacade.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/password/ResetPasswordService.kt
+++ b/src/main/kotlin/org/hkurh/doky/password/ResetPasswordService.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/password/TokenService.kt
+++ b/src/main/kotlin/org/hkurh/doky/password/TokenService.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/password/TokenStatus.kt
+++ b/src/main/kotlin/org/hkurh/doky/password/TokenStatus.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/password/api/PasswordApi.kt
+++ b/src/main/kotlin/org/hkurh/doky/password/api/PasswordApi.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/password/api/PasswordController.kt
+++ b/src/main/kotlin/org/hkurh/doky/password/api/PasswordController.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/password/api/ResetPasswordRequest.kt
+++ b/src/main/kotlin/org/hkurh/doky/password/api/ResetPasswordRequest.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/password/api/UpdatePasswordRequest.kt
+++ b/src/main/kotlin/org/hkurh/doky/password/api/UpdatePasswordRequest.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/password/db/ResetPasswordTokenEntity.kt
+++ b/src/main/kotlin/org/hkurh/doky/password/db/ResetPasswordTokenEntity.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/password/db/ResetPasswordTokenEntityRepository.kt
+++ b/src/main/kotlin/org/hkurh/doky/password/db/ResetPasswordTokenEntityRepository.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/password/impl/DefaultPasswordFacade.kt
+++ b/src/main/kotlin/org/hkurh/doky/password/impl/DefaultPasswordFacade.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/password/impl/DefaultResetPasswordService.kt
+++ b/src/main/kotlin/org/hkurh/doky/password/impl/DefaultResetPasswordService.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/password/impl/DefaultTokenService.kt
+++ b/src/main/kotlin/org/hkurh/doky/password/impl/DefaultTokenService.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/search/DocumentIndexData.kt
+++ b/src/main/kotlin/org/hkurh/doky/search/DocumentIndexData.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/search/LoggingPolicy.kt
+++ b/src/main/kotlin/org/hkurh/doky/search/LoggingPolicy.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/search/index/IndexService.kt
+++ b/src/main/kotlin/org/hkurh/doky/search/index/IndexService.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/search/index/impl/DefaultIndexService.kt
+++ b/src/main/kotlin/org/hkurh/doky/search/index/impl/DefaultIndexService.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/search/schedule/Scheduler.kt
+++ b/src/main/kotlin/org/hkurh/doky/search/schedule/Scheduler.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/search/schedule/impl/DefaultScheduler.kt
+++ b/src/main/kotlin/org/hkurh/doky/search/schedule/impl/DefaultScheduler.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/security/DokyUserDetails.kt
+++ b/src/main/kotlin/org/hkurh/doky/security/DokyUserDetails.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/security/JwtProvider.kt
+++ b/src/main/kotlin/org/hkurh/doky/security/JwtProvider.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/security/SpringSecurityAuditorAware.kt
+++ b/src/main/kotlin/org/hkurh/doky/security/SpringSecurityAuditorAware.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/security/UserAuthority.kt
+++ b/src/main/kotlin/org/hkurh/doky/security/UserAuthority.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/security/impl/DefaultJwtProvider.kt
+++ b/src/main/kotlin/org/hkurh/doky/security/impl/DefaultJwtProvider.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/security/impl/JwtAuthorizationFilter.kt
+++ b/src/main/kotlin/org/hkurh/doky/security/impl/JwtAuthorizationFilter.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/users/UserFacade.kt
+++ b/src/main/kotlin/org/hkurh/doky/users/UserFacade.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/users/UserService.kt
+++ b/src/main/kotlin/org/hkurh/doky/users/UserService.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/users/api/UpdateUserRequest.kt
+++ b/src/main/kotlin/org/hkurh/doky/users/api/UpdateUserRequest.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/users/api/UserApi.kt
+++ b/src/main/kotlin/org/hkurh/doky/users/api/UserApi.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/users/api/UserController.kt
+++ b/src/main/kotlin/org/hkurh/doky/users/api/UserController.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/users/api/UserDto.kt
+++ b/src/main/kotlin/org/hkurh/doky/users/api/UserDto.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/users/db/AuthorityEntity.kt
+++ b/src/main/kotlin/org/hkurh/doky/users/db/AuthorityEntity.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/users/db/AuthorityEntityRepository.kt
+++ b/src/main/kotlin/org/hkurh/doky/users/db/AuthorityEntityRepository.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/users/db/UserEntity.kt
+++ b/src/main/kotlin/org/hkurh/doky/users/db/UserEntity.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/users/db/UserEntityRepository.kt
+++ b/src/main/kotlin/org/hkurh/doky/users/db/UserEntityRepository.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/users/impl/DefaultUserFacade.kt
+++ b/src/main/kotlin/org/hkurh/doky/users/impl/DefaultUserFacade.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/kotlin/org/hkurh/doky/users/impl/DefaultUserService.kt
+++ b/src/main/kotlin/org/hkurh/doky/users/impl/DefaultUserService.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,7 +1,7 @@
 #
 # This file is part of the Doky Project.
 #
-# Copyright (C) 2005
+# Copyright (C) 2022-2025
 #  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
 #  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
 #

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,7 +1,7 @@
 #
 # This file is part of the Doky Project.
 #
-# Copyright (C) 2005
+# Copyright (C) 2022-2025
 #  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
 #  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
 #

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 #
 # This file is part of the Doky Project.
 #
-# Copyright (C) 2005
+# Copyright (C) 2022-2025
 #  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
 #  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
 #

--- a/src/main/resources/bootstrap-local.properties
+++ b/src/main/resources/bootstrap-local.properties
@@ -1,7 +1,7 @@
 #
 # This file is part of the Doky Project.
 #
-# Copyright (C) 2005
+# Copyright (C) 2022-2025
 #  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
 #  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
 #

--- a/src/main/resources/bootstrap-test.properties
+++ b/src/main/resources/bootstrap-test.properties
@@ -1,7 +1,7 @@
 #
 # This file is part of the Doky Project.
 #
-# Copyright (C) 2005
+# Copyright (C) 2022-2025
 #  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
 #  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
 #

--- a/src/main/resources/bootstrap.properties
+++ b/src/main/resources/bootstrap.properties
@@ -1,7 +1,7 @@
 #
 # This file is part of the Doky Project.
 #
-# Copyright (C) 2005
+# Copyright (C) 2022-2025
 #  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
 #  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
 #

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This file is part of the Doky Project.
   ~
-  ~ Copyright (C) 2005
+  ~ Copyright (C) 2022-2025
   ~  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
   ~  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
   ~

--- a/src/main/resources/mail/img/logo-white-no-bg.svg
+++ b/src/main/resources/mail/img/logo-white-no-bg.svg
@@ -1,7 +1,7 @@
 <!--
   - This file is part of the Doky Project.
   -
-  - Copyright (C) 2005
+  - Copyright (C) 2022-2025
   -  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
   -  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
   -

--- a/src/main/resources/mail/templates/registration.html
+++ b/src/main/resources/mail/templates/registration.html
@@ -1,7 +1,7 @@
 <!--
   ~ This file is part of the Doky Project.
   ~
-  ~ Copyright (C) 2005
+  ~ Copyright (C) 2022-2025
   ~  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
   ~  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
   ~

--- a/src/main/resources/mail/templates/restore-password.html
+++ b/src/main/resources/mail/templates/restore-password.html
@@ -1,7 +1,7 @@
 <!--
   ~ This file is part of the Doky Project.
   ~
-  ~ Copyright (C) 2005
+  ~ Copyright (C) 2022-2025
   ~  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
   ~  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
   ~

--- a/src/main/resources/scheduler.properties
+++ b/src/main/resources/scheduler.properties
@@ -1,7 +1,7 @@
 #
 # This file is part of the Doky Project.
 #
-# Copyright (C) 2005
+# Copyright (C) 2022-2025
 #  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
 #  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
 #

--- a/src/test/kotlin/org/hkurh/doky/DokyUnitTest.kt
+++ b/src/test/kotlin/org/hkurh/doky/DokyUnitTest.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/test/kotlin/org/hkurh/doky/authorization/AuthorizationUserControllerTest.kt
+++ b/src/test/kotlin/org/hkurh/doky/authorization/AuthorizationUserControllerTest.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/test/kotlin/org/hkurh/doky/documents/impl/DefaultDocumentFacadeTest.kt
+++ b/src/test/kotlin/org/hkurh/doky/documents/impl/DefaultDocumentFacadeTest.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/test/kotlin/org/hkurh/doky/email/impl/SendgridEmailSenderTest.kt
+++ b/src/test/kotlin/org/hkurh/doky/email/impl/SendgridEmailSenderTest.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/test/kotlin/org/hkurh/doky/email/impl/SmtpEmailSenderTest.kt
+++ b/src/test/kotlin/org/hkurh/doky/email/impl/SmtpEmailSenderTest.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/test/kotlin/org/hkurh/doky/email/impl/TransactionalEmailServiceTest.kt
+++ b/src/test/kotlin/org/hkurh/doky/email/impl/TransactionalEmailServiceTest.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2025
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/test/kotlin/org/hkurh/doky/filestorage/DefaultFileStorageServiceTest.kt
+++ b/src/test/kotlin/org/hkurh/doky/filestorage/DefaultFileStorageServiceTest.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/test/kotlin/org/hkurh/doky/kafka/KafkaEmailNotificationConsumerServiceTest.kt
+++ b/src/test/kotlin/org/hkurh/doky/kafka/KafkaEmailNotificationConsumerServiceTest.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/test/kotlin/org/hkurh/doky/kafka/KafkaEmailNotificationProducerServiceTest.kt
+++ b/src/test/kotlin/org/hkurh/doky/kafka/KafkaEmailNotificationProducerServiceTest.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/test/kotlin/org/hkurh/doky/password/DefaultPasswordFacadeTest.kt
+++ b/src/test/kotlin/org/hkurh/doky/password/DefaultPasswordFacadeTest.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/test/kotlin/org/hkurh/doky/password/DefaultResetPasswordServiceTest.kt
+++ b/src/test/kotlin/org/hkurh/doky/password/DefaultResetPasswordServiceTest.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/test/kotlin/org/hkurh/doky/security/JwtAuthorizationFilterTest.kt
+++ b/src/test/kotlin/org/hkurh/doky/security/JwtAuthorizationFilterTest.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/test/kotlin/org/hkurh/doky/users/DefaultUserFacadeTest.kt
+++ b/src/test/kotlin/org/hkurh/doky/users/DefaultUserFacadeTest.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *

--- a/src/test/kotlin/org/hkurh/doky/users/DefaultUserServiceTest.kt
+++ b/src/test/kotlin/org/hkurh/doky/users/DefaultUserServiceTest.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of the Doky Project.
  *
- * Copyright (C) 2005
+ * Copyright (C) 2022-2025
  *  - Hanna Kurhuzenkava (hanna.kuehuzenkava@outlook.com)
  *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
  *


### PR DESCRIPTION
Update copyright year range to 2022-2025 in all source files to ensure compliance with legal requirements.