### PR TITLE
DOKY-283 Preserve Search Params

### DIFF
--- a/doky-front/src/hooks/useQuery.js
+++ b/doky-front/src/hooks/useQuery.js
@@ -43,7 +43,7 @@ const dedupeRequest = request => {
   };
 };
 
-export const useQuery = request => {
+export const useQuery = (request, { skip = false } = { skip: false }) => {
   const [isLoading, setIsLoading] = useState(true);
   const [data, setData] = useState({});
 
@@ -67,8 +67,10 @@ export const useQuery = request => {
   }, [dedupedRequest]);
 
   useEffect(() => {
-    fetchData();
-  }, [fetchData]);
+    if (!skip) {
+      fetchData();
+    }
+  }, [fetchData, skip]);
 
   return {data, isLoading, refetch: fetchData};
 };

--- a/doky-front/src/pages/Documents/Documents.jsx
+++ b/doky-front/src/pages/Documents/Documents.jsx
@@ -85,29 +85,15 @@ const columns = [
   }
 ];
 
-const STORAGE_KEY = 'documents_search_state';
-
 const Documents = () => {
 
   const [searchParams, setSearchParams] = useSearchParams();
 
-  // Get saved state from sessionStorage
-  const getSavedState = () => {
-    try {
-      const saved = sessionStorage.getItem(STORAGE_KEY);
-      return saved ? JSON.parse(saved) : null;
-    } catch {
-      return null;
-    }
-  };
-
-  const savedState = getSavedState();
-
   // Initialize state from URL params or saved state
-  const initialQuery = searchParams.get('query') || savedState?.query || '';
-  const initialSort = searchParams.get('sort') || savedState?.sort || searchPayload.sort.property;
-  const initialDir = searchParams.get('dir') || savedState?.dir || searchPayload.sort.direction;
-  const initialPage = parseInt(searchParams.get('page') || savedState?.page || '0', 10);
+  const initialQuery = searchParams.get('query') || '';
+  const initialSort = searchParams.get('sort') || searchPayload.sort.property;
+  const initialDir = searchParams.get('dir') || searchPayload.sort.direction;
+  const initialPage = parseInt(searchParams.get('page') || '0', 10);
 
   const {fields: {query}} = useFormData({...searchPayload, query: initialQuery});
   const [debouncedQuery, setDebouncedQuery] = useState(initialQuery);
@@ -159,13 +145,9 @@ const Documents = () => {
     navigate('/documents/create');
   }, [navigate]);
 
-  // Sync URL and sessionStorage with state changes
+  // Sync URL with state changes
   useEffect(() => {
     const params = new URLSearchParams();
-    const state = {
-      query: debouncedQuery,
-      page: paginationModel.page,
-    };
 
     if (debouncedQuery) {
       params.set('query', debouncedQuery);
@@ -174,19 +156,10 @@ const Documents = () => {
     if (sortModel.length > 0) {
       params.set('sort', sortModel[0].field);
       params.set('dir', sortModel[0].sort.toUpperCase());
-      state.sort = sortModel[0].field;
-      state.dir = sortModel[0].sort.toUpperCase();
     }
 
     if (paginationModel.page > 0) {
       params.set('page', paginationModel.page.toString());
-    }
-
-    // Save to sessionStorage
-    try {
-      sessionStorage.setItem(STORAGE_KEY, JSON.stringify(state));
-    } catch {
-      // Ignore storage errors
     }
 
     setSearchParams(params, { replace: true });

--- a/doky-front/src/pages/Documents/Documents.jsx
+++ b/doky-front/src/pages/Documents/Documents.jsx
@@ -27,7 +27,7 @@ import Typography from '@mui/material/Typography';
 import AddIcon from '@mui/icons-material/Add';
 import {DataGrid} from '@mui/x-data-grid';
 import { useDocumentsSearchParams } from './searchParams';
-import { SearchInput } from './SearchInput.jsx';
+import { SearchInput } from './SearchInput';
 
 const columns = [
   {

--- a/doky-front/src/pages/Documents/Documents.jsx
+++ b/doky-front/src/pages/Documents/Documents.jsx
@@ -17,30 +17,17 @@
  *  - Project Homepage: https://github.com/hanna-eismant/doky
  */
 
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
-import {Link, useNavigate, useSearchParams} from 'react-router-dom';
+import React, {useCallback, useMemo, useState} from 'react';
+import {Link, useNavigate} from 'react-router-dom';
 import {useQuery} from '../../hooks/useQuery';
 import {searchDocuments} from '../../api/documents';
-import {Button, InputAdornment, Stack, TextField} from '@mui/material';
-import {debounce} from '@mui/material/utils';
+import {Button, Stack } from '@mui/material';
 import Breadcrumbs from '@mui/material/Breadcrumbs';
 import Typography from '@mui/material/Typography';
-import SearchIcon from '@mui/icons-material/Search';
 import AddIcon from '@mui/icons-material/Add';
-import {useFormData} from '../../hooks/useFormData';
 import {DataGrid} from '@mui/x-data-grid';
-
-const searchPayload = {
-  query: '',
-  page: {
-    number: 0,
-    size: 10
-  },
-  sort: {
-    property: 'createdDate',
-    direction: 'DESC'
-  }
-};
+import { useDocumentsSearchParams } from './searchParams';
+import { SearchInput } from './SearchInput.jsx';
 
 const columns = [
   {
@@ -87,83 +74,70 @@ const columns = [
 
 const Documents = () => {
 
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useDocumentsSearchParams();
 
-  // Initialize state from URL params or saved state
-  const initialQuery = searchParams.get('query') || '';
-  const initialSort = searchParams.get('sort') || searchPayload.sort.property;
-  const initialDir = searchParams.get('dir') || searchPayload.sort.direction;
-  const initialPage = parseInt(searchParams.get('page') || '0', 10);
+  /* The searchParams object has already been normalized by ../searchParams/searchParamsNormalizer,
+    ensuring that all expected parameters are present and set to default values if missing.
+    Therefore, we can safely destructure the required parameters without additional existence checks. */
+  const { query, sort, dir } = searchParams;
+  const page = parseInt(searchParams.page, 10);
 
-  const {fields: {query}} = useFormData({...searchPayload, query: initialQuery});
-  const [debouncedQuery, setDebouncedQuery] = useState(initialQuery);
-  const [paginationModel, setPaginationModel] = useState({
-    page: initialPage,
-    pageSize: 0
-  });
-  const [sortModel, setSortModel] = useState([
-    {
-      field: initialSort,
-      sort: initialDir.toLowerCase()
+  const [ pageSize, setPageSize ] = useState(0);
+  const paginationModel = useMemo(() => ({ page, pageSize }), [page, pageSize]);
+
+  const onPaginationModelChange = ({ page: newPage, pageSize: newPageSize }) => {
+    // This handler may be triggered multiple times during initial load, sometimes with unchanged values.
+    // Only update state if the newPageSize differ from the current one to avoid unnecessary re-renders.
+    if (newPage !== page) {
+      setSearchParams({ page: newPage });
     }
-  ]);
+    setPageSize(newPageSize);
+  };
 
-  const debouncedSetQuery = useMemo(() =>
-    debounce((value) => {
-      setDebouncedQuery(value);
-    }, 500),
-  []
-  );
+  const onSortModelChange = (model) => {
+    if (model.length === 0) {
+      return;
+    }
 
-  const handleSearchChange = (e) => {
-    const value = e.target.value;
-    query.setValue(value);
-    debouncedSetQuery(value);
+    const [ { field, sort }] = model;
+    setSearchParams({
+      sort: field,
+      dir: sort.toUpperCase()
+    });
+  };
+
+  const sortModel = useMemo(() => [{
+    field: sort,
+    sort: dir.toLowerCase()
+  }], [dir, sort]);
+
+  const handleSearchChange = value => {
+    setSearchParams({ query: value });
   };
 
   const search = useCallback(() => {
-    const sort = sortModel.length > 0
-      ? {
-        property: sortModel[0].field,
-        direction: sortModel[0].sort.toUpperCase()
-      }
-      : searchPayload.sort;
+    const sort =  {
+      property: sortModel[0].field,
+      direction: sortModel[0].sort.toUpperCase()
+    };
 
     const page = {
       number: paginationModel.page,
       size: paginationModel.pageSize
     };
 
-    return searchDocuments({...searchPayload, query: debouncedQuery, page, sort});
-  }, [debouncedQuery, paginationModel, sortModel]);
+    return searchDocuments({ query: query, page, sort});
+  }, [query, paginationModel.page, paginationModel.pageSize, sortModel]);
 
-  const {isLoading, data} = useQuery(search);
+  // page size calculated dynamically based on layout. Initially it is zero.
+  // So, it is needed to skip initial API request
+  const {isLoading, data} = useQuery(search, { skip: pageSize === 0 });
 
   const navigate = useNavigate();
 
   const goToCreateDocument = useCallback(() => {
     navigate('/documents/create');
   }, [navigate]);
-
-  // Sync URL with state changes
-  useEffect(() => {
-    const params = new URLSearchParams();
-
-    if (debouncedQuery) {
-      params.set('query', debouncedQuery);
-    }
-
-    if (sortModel.length > 0) {
-      params.set('sort', sortModel[0].field);
-      params.set('dir', sortModel[0].sort.toUpperCase());
-    }
-
-    if (paginationModel.page > 0) {
-      params.set('page', paginationModel.page.toString());
-    }
-
-    setSearchParams(params, { replace: true });
-  }, [debouncedQuery, sortModel, paginationModel, setSearchParams]);
 
   return (
     <Stack spacing={5}
@@ -188,25 +162,16 @@ const Documents = () => {
         </Button>
       </Stack>
 
-      <TextField
-        fullWidth
-        label="Search"
-        id="outlined-size-small"
-        value={query.value}
-        onChange={handleSearchChange}
-        size="small"
-        inputProps={{'data-cy': 'documents-search-input'}}
-        InputLabelProps={{'data-cy': 'documents-search-label'}}
-        slotProps={{
-          input: {
-            endAdornment: (
-              <InputAdornment position="end">
-                <SearchIcon/>
-              </InputAdornment>
-            ),
-          },
-        }}
+      {/*
+      NOTE: SearchInput is an uncontrolled component.
+      This means that updating the 'defaultValue' prop after the initial render
+      will NOT update the input's displayed value.
+    */}
+      <SearchInput
+        defaultValue={query}
+        onValueChange={handleSearchChange}
       />
+
       <DataGrid
         loading={isLoading}
         sx={{
@@ -222,9 +187,9 @@ const Documents = () => {
         onRowClick={(params) => navigate(`/documents/${params.id}`)}
         paginationMode="server"
         paginationModel={paginationModel}
-        onPaginationModelChange={setPaginationModel}
+        onPaginationModelChange={onPaginationModelChange}
         sortModel={sortModel}
-        onSortModelChange={setSortModel}
+        onSortModelChange={onSortModelChange}
         sortingOrder={['asc', 'desc']}
         disableColumnFilter
         autoPageSize

--- a/doky-front/src/pages/Documents/SearchInput.jsx
+++ b/doky-front/src/pages/Documents/SearchInput.jsx
@@ -17,22 +17,39 @@
  *  - Project Homepage: https://github.com/hanna-eismant/doky
  */
 
-export const noop = () => {
-};
+import React, { useMemo } from 'react';
 
-export const getFalse = () => false;
+import { debounce, InputAdornment, TextField} from '@mui/material';
+import SearchIcon from '@mui/icons-material/Search';
 
-export const getRowsCount = str =>
-  str.split('\n').length;
+export const SearchInput = React.memo(function SearchInput({ defaultValue, onValueChange }) {
 
-export const clamp = (value, min, max) => {
-  if (value < min) {
-    return min;
-  }
+  const debouncedOnValueChange = useMemo(() => debounce(e => {
+    onValueChange(e.target.value);
+  }, 500), [onValueChange]);
 
-  if (value > max) {
-    return max;
-  }
+  return (
+    <TextField
+      fullWidth
+      label="Search"
+      id="outlined-size-small"
+      defaultValue={defaultValue}
+      onChange={debouncedOnValueChange}
+      size="small"
+      InputLabelProps={{'data-cy': 'documents-search-label'}}
+      slotProps={{
+        input: {
+          endAdornment: (
+            <InputAdornment position="end">
+              <SearchIcon/>
+            </InputAdornment>
+          ),
+        },
+        htmlInput: {
+          'data-cy': 'documents-search-input'
+        }
+      }}
+    />
+  );
+});
 
-  return value;
-};

--- a/doky-front/src/pages/Documents/searchParams.js
+++ b/doky-front/src/pages/Documents/searchParams.js
@@ -1,0 +1,50 @@
+import { useCallback } from 'react';
+
+import { replace, useSearchParams } from 'react-router-dom';
+
+const staticSearchParams = {
+  page: 0
+};
+
+const defaultSearchParams = {
+  query: '',
+  sort: 'createdDate',
+  dir: 'DESC',
+  ...staticSearchParams
+};
+
+/**
+ * Normalizes search parameters in the request URL.
+ * - If all required parameters are present in the URL, no normalization is needed.
+ * - If any parameter is missing, merges defaults and static params, and returns a redirect URL with normalized params.
+ */
+export const searchParamsNormalizer = ({ request }) => {
+  const rawSearchParams = new URL(request.url).searchParams;
+  const searchParams = Object.fromEntries(rawSearchParams.entries());
+  const searchParamsKeys = Object.keys(searchParams);
+
+  // If all expected parameters are present in the URL, update defaults and return null (no redirect needed)
+  if (Object.keys(defaultSearchParams).every(key => searchParamsKeys.includes(key))) {
+    Object.assign(defaultSearchParams, searchParams, staticSearchParams);
+    return null;
+  }
+
+  // If any parameter is missing, merge defaults and static params, and return a redirect URL with normalized params
+  Object.assign(defaultSearchParams, searchParams, staticSearchParams);
+  return replace(`?${new URLSearchParams(defaultSearchParams)}`);
+};
+
+export const useDocumentsSearchParams = () => {
+  const [rawSearchParams, setRawSearchParams] = useSearchParams();
+
+  const searchParams = Object.fromEntries(rawSearchParams.entries());
+
+  const setSearchParams = useCallback(params => {
+    setRawSearchParams({ ...searchParams, ...params });
+  }, [searchParams, setRawSearchParams]);
+
+  return [
+    searchParams,
+    setSearchParams
+  ];
+};

--- a/doky-front/src/pages/Home/Home.jsx
+++ b/doky-front/src/pages/Home/Home.jsx
@@ -40,15 +40,13 @@ const searchPayload = {
   }
 };
 
+const search = () => searchDocuments(searchPayload);
+
 const Home = () => {
 
   const navigate = useNavigate();
 
   const user = useUser();
-
-  const search = useCallback(() => {
-    return searchDocuments(searchPayload);
-  }, []);
 
   const {isLoading, data} = useQuery(search);
 

--- a/doky-front/src/routing/routes.js
+++ b/doky-front/src/routing/routes.js
@@ -31,7 +31,7 @@ import UpdatePassword from '../pages/UpdatePassword';
 import ErrorPage from '../pages/Error';
 import NotFoundPage from '../pages/NotFound';
 import { searchParamsNormalizer } from '../pages/Documents/searchParams';
-import { getFalse } from '../utils.js';
+import { getFalse } from '../utils';
 
 export const mainPageRoute = {
   id: 'main', // used for accessing data fetched by this route loader

--- a/doky-front/src/routing/routes.js
+++ b/doky-front/src/routing/routes.js
@@ -30,16 +30,19 @@ import ResetPassword from '../pages/ResetPassword';
 import UpdatePassword from '../pages/UpdatePassword';
 import ErrorPage from '../pages/Error';
 import NotFoundPage from '../pages/NotFound';
+import { searchParamsNormalizer } from '../pages/Documents/searchParams';
+import { getFalse } from '../utils.js';
 
 export const mainPageRoute = {
   id: 'main', // used for accessing data fetched by this route loader
   element: <MainPage/>,
   path: '/',
   loader: mainPageLoader,
+  shouldRevalidate: getFalse,
   errorElement: <ErrorPage/>,
   children: [
     {index: true, element: <Home/>},
-    {path: 'documents', element: <Documents/>},
+    {path: 'documents', element: <Documents/>, loader: searchParamsNormalizer },
     {path: 'documents/create', element: <CreateDocumentPage/>},
     {path: 'documents/:id', element: <DocumentPage/>},
     {path: 'profile', element: <UserProfile/>}


### PR DESCRIPTION
## Core Changes  

-  [Added functionality to populate "default" (or previously used) parameters in the URL](https://github.com/hanna-eismant/doky/pull/213/changes#diff-8b2fcd29ac1dedce52c17ec79ce210811948b8227e6b5238908913e386aaf0e0R16). While this introduces a side effect rather than just data loading, it aligns with the documentation (https://reactrouter.com/6.30.3/fetch/redirect#redirect). We are already [using](https://github.com/hanna-eismant/doky/blob/main/doky-front/src/routing/loaders.js) a similar approach to redirect unauthenticated users to the login page.  
-  [Removed the synchronization of search params from the URL to the local component state](https://github.com/hanna-eismant/doky/pull/213/changes#diff-7b2a5869ca3b7abdf8e7dc30eb151cca53315969fd2e43262e03f4b5aeab66c9L163) via `useEffect` to honor the single source of truth principle and to prevent unnecessary re-renders caused by `useEffect` (except for `pageSize`).  
- [Removed the logic for storing search params in session storage](https://github.com/hanna-eismant/doky/pull/213/changes#diff-7b2a5869ca3b7abdf8e7dc30eb151cca53315969fd2e43262e03f4b5aeab66c9L95).  

## Misc  

- Added [shouldRevalidate](https://reactrouter.com/6.30.3/route/should-revalidate#shouldrevalidate): () => false  to prevent unnecessary calls to `users/current`.  
-  Added the [skip](https://github.com/hanna-eismant/doky/pull/213/changes#diff-7b2a5869ca3b7abdf8e7dc30eb151cca53315969fd2e43262e03f4b5aeab66c9R137) flag in the query to skip the initial search request with a zero page size.  
- Reduced redundant state updates and avoided unwanted API requests caused by multiple calls with the same `pageSize` by [onPaginationModelChange](https://github.com/hanna-eismant/doky/pull/213/changes#diff-7b2a5869ca3b7abdf8e7dc30eb151cca53315969fd2e43262e03f4b5aeab66c9L95)
- Introduced a `SearchInput` [component](https://github.com/hanna-eismant/doky/pull/213/changes#diff-de25861b51e0c72aeb534b6907a3699aae6c16b061cc2af13628d7d0aca50181) that uses `defaultValue` for the input (making it uncontrolled). As a minor pitfall, programmatically updating the input value (e.g., by setting state after the initial render) may lead to challenges.  