### PR TITLE
DOKY-267 Improve code coverage

### DIFF
--- a/src/main/kotlin/org/hkurh/doky/Utils.kt
+++ b/src/main/kotlin/org/hkurh/doky/Utils.kt
@@ -20,13 +20,16 @@
 package org.hkurh.doky
 
 import java.security.SecureRandom
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.util.*
 
 fun String.mask(
     startLength: Int = 3,
     endLength: Int = 3,
     maskChar: Char = '*'
 ): String {
-
     if (this.isEmpty() || this.length < startLength + endLength) {
         return maskChar.toString().repeat(this.length)
     }
@@ -38,7 +41,6 @@ fun String.mask(
 
 fun String?.getExtension(): String {
     return this?.substringAfterLast('.', "") ?: ""
-
 }
 
 fun generateSecureRandomString(length: Int = 10): String {
@@ -47,4 +49,12 @@ fun generateSecureRandomString(length: Int = 10): String {
     return (1..length)
         .map { allowedChars[secureRandom.nextInt(allowedChars.size)] }
         .joinToString("")
+}
+
+fun LocalDateTime.toUtcDate(): Date {
+    return Date.from(this.toInstant(ZoneOffset.UTC))
+}
+
+fun LocalDateTime.toUtcInstant(): Instant {
+    return this.toInstant(ZoneOffset.UTC)
 }

--- a/src/main/kotlin/org/hkurh/doky/config/TimeConfig.kt
+++ b/src/main/kotlin/org/hkurh/doky/config/TimeConfig.kt
@@ -17,25 +17,15 @@
  *  - Project Homepage: https://github.com/hanna-eismant/doky
  */
 
-package org.hkurh.doky.password
+package org.hkurh.doky.config
 
-import java.util.*
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Clock
 
-/**
- * TokenService interface provides methods for generating tokens and calculating their expiration date.
- */
-interface TokenService {
-    /**
-     * Calculates the expiration date for a token.
-     *
-     * @return The expiration date for the token.
-     */
-    fun calculateExpirationDate(): Date
+@Configuration
+class TimeConfig {
 
-    /**
-     * Generates a token.
-     *
-     * @return The generated token as a string.
-     */
-    fun generateToken(): String
+    @Bean
+    fun clock(): Clock = Clock.systemUTC()
 }

--- a/src/main/kotlin/org/hkurh/doky/password/PasswordTokenService.kt
+++ b/src/main/kotlin/org/hkurh/doky/password/PasswordTokenService.kt
@@ -17,32 +17,25 @@
  *  - Project Homepage: https://github.com/hanna-eismant/doky
  */
 
-package org.hkurh.doky.password.impl
+package org.hkurh.doky.password
 
-import org.hkurh.doky.password.TokenService
-import org.springframework.beans.factory.annotation.Value
-import org.springframework.stereotype.Component
-import java.time.Instant
-import java.time.LocalDateTime
-import java.time.ZoneId
-import java.time.ZoneOffset
-import java.util.*
+import java.util.Date
 
-@Component
-class DefaultTokenService : TokenService {
+/**
+ * This interface provides methods for generating reset password tokens and calculating their expiration date.
+ */
+interface PasswordTokenService {
+    /**
+     * Calculates the expiration date for a token.
+     *
+     * @return The expiration date for the token.
+     */
+    fun calculateExpirationDate(): Date
 
-    private val zoneId = ZoneId.of("UTC")
-
-    @Value("\${doky.password.reset.token.duration}")
-    private var resetTokenDuration: Long = 10
-
-    override fun calculateExpirationDate(): Date {
-        val currentDate = LocalDateTime.ofInstant(Instant.now(), zoneId)
-        val expiredDate = currentDate.plusMinutes(resetTokenDuration)
-        return Date.from(expiredDate.toInstant(ZoneOffset.UTC))
-    }
-
-    override fun generateToken(): String {
-        return UUID.randomUUID().toString()
-    }
+    /**
+     * Generates a token.
+     *
+     * @return The generated token as a string.
+     */
+    fun generateToken(): String
 }

--- a/src/main/kotlin/org/hkurh/doky/password/impl/DefaultPasswordTokenService.kt
+++ b/src/main/kotlin/org/hkurh/doky/password/impl/DefaultPasswordTokenService.kt
@@ -1,0 +1,39 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2022-2026
+ *  - Hanna Kurhuzenkava (hanna.kurhuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
+package org.hkurh.doky.password.impl
+
+import org.hkurh.doky.password.PasswordTokenService
+import org.hkurh.doky.toUtcDate
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.time.Clock
+import java.time.LocalDateTime
+import java.util.*
+
+@Component
+class DefaultPasswordTokenService(
+    @set:Value("\${doky.password.reset.token.duration}") private var resetTokenDuration: Long = 10,
+    private val clock: Clock
+) : PasswordTokenService {
+
+    override fun calculateExpirationDate(): Date = LocalDateTime.now(clock).plusMinutes(resetTokenDuration).toUtcDate()
+
+    override fun generateToken(): String = UUID.randomUUID().toString()
+}

--- a/src/main/kotlin/org/hkurh/doky/password/impl/DefaultResetPasswordService.kt
+++ b/src/main/kotlin/org/hkurh/doky/password/impl/DefaultResetPasswordService.kt
@@ -23,24 +23,28 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import org.hkurh.doky.errorhandling.DokyNotFoundException
 import org.hkurh.doky.mask
 import org.hkurh.doky.password.ResetPasswordService
-import org.hkurh.doky.password.TokenService
+import org.hkurh.doky.password.PasswordTokenService
 import org.hkurh.doky.password.TokenStatus
 import org.hkurh.doky.password.db.ResetPasswordTokenEntity
 import org.hkurh.doky.password.db.ResetPasswordTokenEntityRepository
+import org.hkurh.doky.toUtcInstant
 import org.hkurh.doky.users.db.UserEntity
 import org.springframework.stereotype.Service
+import java.time.Clock
+import java.time.LocalDateTime
 
 @Service
 class DefaultResetPasswordService(
-    private val tokenService: TokenService,
+    private val passwordTokenService: PasswordTokenService,
     private val resetPasswordTokenEntityRepository: ResetPasswordTokenEntityRepository,
+    private val clock: Clock
 ) : ResetPasswordService {
 
     private val log = KotlinLogging.logger {}
 
     override fun generateAndSaveResetToken(user: UserEntity): String {
-        val token = tokenService.generateToken()
-        val expirationDate = tokenService.calculateExpirationDate()
+        val token = passwordTokenService.generateToken()
+        val expirationDate = passwordTokenService.calculateExpirationDate()
         val resetPasswordTokenEntity = ResetPasswordTokenEntity().apply {
             this.token = token
             this.user = user
@@ -77,5 +81,5 @@ class DefaultResetPasswordService(
     }
 
     private fun isTokenExpired(token: ResetPasswordTokenEntity) =
-        token.expirationDate.toInstant().isBefore(java.time.Instant.now())
+        token.expirationDate.toInstant().isBefore(LocalDateTime.now(clock).toUtcInstant())
 }

--- a/src/main/kotlin/org/hkurh/doky/search/impl/AlgoliaDocumentSearchService.kt
+++ b/src/main/kotlin/org/hkurh/doky/search/impl/AlgoliaDocumentSearchService.kt
@@ -49,7 +49,7 @@ import org.springframework.stereotype.Service
 class AlgoliaDocumentSearchService(
     private val userService: UserService,
     private val searchClient: SearchClient,
-    @Value("\${algolia.search.index-name}") private val indexName: String = "",
+    @field:Value("\${algolia.search.index-name}") private val indexName: String = "",
 ) : DocumentSearchService {
 
     private val log = KotlinLogging.logger {}
@@ -77,21 +77,13 @@ class AlgoliaDocumentSearchService(
         val result = searchClient.searchSingleIndex(targetIndex, params, DocumentResultData::class.java)
         log.debug { "Search query=[$query], index=[$targetIndex], page=[$pageNumber], size=[$pageSize], nbHits=[${result.nbHits}]" }
         log.debug { "Search result: [$result]" }
-        return SearchResult(result.hits, result.nbHits ?: 0, result.page ?: 0,result.nbPages ?: 0)
+        return SearchResult(result.hits, result.nbHits ?: 0, result.page ?: 0, result.nbPages ?: 0)
     }
 
     private fun buildAllowedUsersFilter(userId: Long): String {
         return "allowedUsers:\"$userId\""
     }
 
-    /**
-     * Algolia sorting is normally done via replica indices.
-     * Example replica naming convention:
-     *   <baseIndex>_createdDateTs_desc
-     *   <baseIndex>_createdDateTs_asc
-     *
-     * If you don't have replicas of some sorts, fall back to the base index.
-     */
     private fun resolveIndexNameForSort(sort: Sort): String {
         val property = sort.property?.trim().takeUnless { it.isNullOrEmpty() } ?: return indexName
         val direction = sort.direction ?: return indexName

--- a/src/main/kotlin/org/hkurh/doky/search/impl/AlgoliaDocumentSearchService.kt
+++ b/src/main/kotlin/org/hkurh/doky/search/impl/AlgoliaDocumentSearchService.kt
@@ -70,7 +70,7 @@ class AlgoliaDocumentSearchService(
 
         val params = SearchParamsObject()
             .setQuery(query)
-            .setPage(pageNumber)          // Algolia page is 0-based
+            .setPage(pageNumber)
             .setHitsPerPage(pageSize)
             .setFilters(filters)
 
@@ -90,7 +90,7 @@ class AlgoliaDocumentSearchService(
      *   <baseIndex>_createdDateTs_desc
      *   <baseIndex>_createdDateTs_asc
      *
-     * If you don't have replicas for some sorts, fall back to the base index.
+     * If you don't have replicas of some sorts, fall back to the base index.
      */
     private fun resolveIndexNameForSort(sort: Sort): String {
         val property = sort.property?.trim().takeUnless { it.isNullOrEmpty() } ?: return indexName

--- a/src/main/kotlin/org/hkurh/doky/security/impl/DefaultJwtProvider.kt
+++ b/src/main/kotlin/org/hkurh/doky/security/impl/DefaultJwtProvider.kt
@@ -22,17 +22,19 @@ package org.hkurh.doky.security.impl
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.SignatureAlgorithm
 import org.hkurh.doky.security.JwtProvider
+import org.hkurh.doky.toUtcDate
 import org.hkurh.doky.users.db.UserEntity
-import org.joda.time.DateTime
-import org.joda.time.DateTimeZone
 import org.springframework.stereotype.Component
+import java.time.Clock
+import java.time.LocalDateTime
 import java.util.*
 import javax.crypto.spec.SecretKeySpec
 
 
 @Component
 class DefaultJwtProvider(
-    private val secretKeySpec: SecretKeySpec
+    private val secretKeySpec: SecretKeySpec,
+    private val clock: Clock
 ) : JwtProvider {
 
     private val jwtParser = Jwts.parserBuilder().setSigningKey(secretKeySpec).build()
@@ -43,7 +45,7 @@ class DefaultJwtProvider(
     private val downloadTokenId = "dokyDownloadToken"
 
     override fun generateToken(username: String, roles: Set<Any>): String {
-        val currentTime = DateTime(DateTimeZone.getDefault())
+        val currentTime = LocalDateTime.now(clock)
         val expireTokenTime = currentTime.plusDays(1)
         val claims = mapOf(
             idKey to authTokenId,
@@ -52,22 +54,22 @@ class DefaultJwtProvider(
         )
         return Jwts.builder()
             .setClaims(claims)
-            .setIssuedAt(currentTime.toDate())
-            .setExpiration(expireTokenTime.toDate())
+            .setIssuedAt(currentTime.toUtcDate())
+            .setExpiration(expireTokenTime.toUtcDate())
             .signWith(secretKeySpec, SignatureAlgorithm.HS256)
             .compact()
     }
 
     override fun generateDownloadToken(user: UserEntity): String {
-        val currentTime = DateTime(DateTimeZone.getDefault())
+        val currentTime = LocalDateTime.now(clock)
         val expireTokenTime = currentTime.plusMinutes(10)
         val claims = mapOf(
             idKey to downloadTokenId
         )
         return Jwts.builder()
             .setClaims(claims)
-            .setIssuedAt(currentTime.toDate())
-            .setExpiration(expireTokenTime.toDate())
+            .setIssuedAt(currentTime.toUtcDate())
+            .setExpiration(expireTokenTime.toUtcDate())
             .signWith(secretKeySpec, SignatureAlgorithm.HS256)
             .compact()
     }

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -46,9 +46,5 @@ spring.kafka.properties.sasl.jaas.config=
 doky.kafka.emails.topic=emails-test
 doky.kafka.documents.topic=documents-test
 
-# search
-azure.search.endpoint=https://localhost:8443
-azure.search.api-key=api-key
-azure.search.index-name=documents-test
 # logging
 logging.level.org.hkurh.doky=DEBUG

--- a/src/test/kotlin/org/hkurh/doky/password/DefaultResetPasswordServiceTest.kt
+++ b/src/test/kotlin/org/hkurh/doky/password/DefaultResetPasswordServiceTest.kt
@@ -20,6 +20,7 @@
 package org.hkurh.doky.password
 
 import org.hkurh.doky.DokyUnitTest
+import org.hkurh.doky.errorhandling.DokyNotFoundException
 import org.hkurh.doky.password.db.ResetPasswordTokenEntity
 import org.hkurh.doky.password.db.ResetPasswordTokenEntityRepository
 import org.hkurh.doky.password.impl.DefaultResetPasswordService
@@ -28,40 +29,46 @@ import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
 import java.util.*
 
 
 @DisplayName("DefaultResetPasswordService unit test")
 class DefaultResetPasswordServiceTest : DokyUnitTest {
 
-    private var tokenService: TokenService = mock()
-    private var resetPasswordTokenEntityRepository: ResetPasswordTokenEntityRepository = mock()
-    private var resetPasswordService = DefaultResetPasswordService(
-        tokenService = tokenService,
-        resetPasswordTokenEntityRepository = resetPasswordTokenEntityRepository
+    private val fixedInstant = Instant.parse("2022-01-01T00:00:00.00Z")
+    private val clock = Clock.fixed(fixedInstant, ZoneId.of("UTC"))
+    private val passwordTokenService: PasswordTokenService = mock()
+    private val resetPasswordTokenEntityRepository: ResetPasswordTokenEntityRepository = mock()
+    private val resetPasswordService = DefaultResetPasswordService(
+        passwordTokenService,
+        resetPasswordTokenEntityRepository, clock
     )
 
-    private val mockUser = mock<UserEntity>()
-    private val tokenId: Long = 1
+    private val testUser = UserEntity()
     private val tokenString = "test-token"
-    private val tokenDate = Date()
 
     @Test
     @DisplayName("Should save token info in database")
     fun shouldSaveTokenInfoInDatabase() {
-        // when
-        whenever(tokenService.generateToken()).thenReturn(tokenString)
-        whenever(tokenService.calculateExpirationDate()).thenReturn(tokenDate)
+        // given
+        val tokenId: Long = 1
+        val tokenDate = Date()
+        whenever(passwordTokenService.generateToken()).thenReturn(tokenString)
+        whenever(passwordTokenService.calculateExpirationDate()).thenReturn(tokenDate)
 
         whenever(resetPasswordTokenEntityRepository.save(any<ResetPasswordTokenEntity>())).thenAnswer { invocation ->
             val argument = invocation.getArgument<ResetPasswordTokenEntity>(0)
             assertAll(
-                { assertEquals(mockUser, argument.user) },
+                { assertEquals(testUser, argument.user) },
                 { assertEquals(tokenString, argument.token) },
                 { assertEquals(tokenDate, argument.expirationDate) }
             )
@@ -70,7 +77,7 @@ class DefaultResetPasswordServiceTest : DokyUnitTest {
         }
 
         // when
-        val token = resetPasswordService.generateAndSaveResetToken(mockUser)
+        val token = resetPasswordService.generateAndSaveResetToken(testUser)
 
         // then
         assertEquals(token, tokenString)
@@ -101,7 +108,7 @@ class DefaultResetPasswordServiceTest : DokyUnitTest {
         }
         val resetPasswordTokenEntity = ResetPasswordTokenEntity().apply {
             this.token = token
-            this.expirationDate = Date(System.currentTimeMillis() - 30_000)
+            this.expirationDate = Date.from(Instant.parse("2021-01-01T00:03:00Z"))
             this.user = tokenUser
         }
         whenever(resetPasswordTokenEntityRepository.findByToken(token)).thenReturn(resetPasswordTokenEntity)
@@ -133,5 +140,31 @@ class DefaultResetPasswordServiceTest : DokyUnitTest {
 
         // then
         assertEquals(TokenStatus.VALID, actualStatus)
+    }
+
+    @Test
+    @DisplayName("Should get user from token when exists")
+    fun shouldGetUserFromToken_whenExists() {
+        // given
+        val tokenEntity = ResetPasswordTokenEntity().apply {
+            user = testUser
+        }
+        whenever(resetPasswordTokenEntityRepository.findByToken(tokenString)).thenReturn(tokenEntity)
+
+        // when
+        val actualUser = resetPasswordService.getUserForToken(tokenString)
+
+        // then
+        assertEquals(testUser, actualUser)
+    }
+
+    @Test
+    @DisplayName("Should throw exception when get user from token and does not exists")
+    fun shouldThrowException_whenGetUserFromToken_whenDoesNotExist() {
+        // given
+        whenever(resetPasswordTokenEntityRepository.findByToken(tokenString)).thenReturn(null)
+
+        // when - then
+        assertThrows<DokyNotFoundException> { resetPasswordService.getUserForToken(tokenString) }
     }
 }

--- a/src/test/kotlin/org/hkurh/doky/password/impl/DefaultPasswordTokenServiceTest.kt
+++ b/src/test/kotlin/org/hkurh/doky/password/impl/DefaultPasswordTokenServiceTest.kt
@@ -1,0 +1,49 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2022-2026
+ *  - Hanna Kurhuzenkava (hanna.kurhuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
+package org.hkurh.doky.password.impl
+
+import org.hkurh.doky.DokyUnitTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.util.Date
+
+@DisplayName("DefaultTokenService unit test")
+class DefaultPasswordTokenServiceTest : DokyUnitTest {
+
+    @Test
+    @DisplayName("Should calculate expiration date")
+    fun shouldCalculateExpirationDate() {
+        // given
+        val fixedInstant = Instant.parse("2022-01-01T00:00:00.00Z")
+        val clock = Clock.fixed(fixedInstant, ZoneId.of("UTC"))
+        val tokenService = DefaultPasswordTokenService(3, clock)
+
+        // when
+        val actualExpirationDate = tokenService.calculateExpirationDate()
+
+        // then
+        val expectedExpirationDate = Date.from(Instant.parse("2022-01-01T00:03:00Z"))
+        assertEquals(expectedExpirationDate, actualExpirationDate)
+    }
+}

--- a/src/test/kotlin/org/hkurh/doky/search/impl/AlgoliaDocumentSearchServiceTest.kt
+++ b/src/test/kotlin/org/hkurh/doky/search/impl/AlgoliaDocumentSearchServiceTest.kt
@@ -1,0 +1,28 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2022-2026
+ *  - Hanna Kurhuzenkava (hanna.kurhuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
+package org.hkurh.doky.search.impl
+
+import org.hkurh.doky.DokyUnitTest
+import org.junit.jupiter.api.DisplayName
+
+@DisplayName("AlgoliaDocumentSearchService unit test")
+class AlgoliaDocumentSearchServiceTest : DokyUnitTest {
+
+}

--- a/src/test/kotlin/org/hkurh/doky/search/impl/AlgoliaDocumentSearchServiceTest.kt
+++ b/src/test/kotlin/org/hkurh/doky/search/impl/AlgoliaDocumentSearchServiceTest.kt
@@ -19,10 +19,138 @@
 
 package org.hkurh.doky.search.impl
 
+import com.algolia.api.SearchClient
+import com.algolia.model.search.SearchParamsObject
+import com.algolia.model.search.SearchResponse
 import org.hkurh.doky.DokyUnitTest
+import org.hkurh.doky.documents.api.Page
+import org.hkurh.doky.documents.api.Sort
+import org.hkurh.doky.documents.api.SortDirection
+import org.hkurh.doky.search.DocumentResultData
+import org.hkurh.doky.users.UserService
+import org.hkurh.doky.users.db.UserEntity
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.stream.Stream
 
 @DisplayName("AlgoliaDocumentSearchService unit test")
 class AlgoliaDocumentSearchServiceTest : DokyUnitTest {
 
+    private val userService: UserService = mock()
+    private val searchClient: SearchClient = mock()
+    private val indexName: String = "documents"
+
+    private val algoliaDocumentSearchService = AlgoliaDocumentSearchService(userService, searchClient, indexName)
+
+    @Test
+    @DisplayName("Should perform search with provided parameters")
+    fun shouldPerformSearchWithProvidedParameters() {
+        // given
+        val expectedPageNumber = 3
+        val expectedPageSize = 13
+        val page = Page(expectedPageNumber, expectedPageSize)
+        val sort = Sort("createdDate", SortDirection.DESC)
+        whenever(userService.getCurrentUser()).thenReturn(createUser())
+        val searchResponse = createSearchResult()
+        whenever(searchClient.searchSingleIndex(any(), any(), eq(DocumentResultData::class.java)))
+            .thenReturn(searchResponse)
+
+        // when
+        algoliaDocumentSearchService.search("", page, sort)
+
+        // then
+        argumentCaptor<SearchParamsObject> {
+            verify(searchClient).searchSingleIndex(
+                eq("documents_createdDateTs_desc"),
+                capture(),
+                eq(DocumentResultData::class.java)
+            )
+            val actualParams = firstValue
+            assertEquals(expectedPageNumber, actualParams.page)
+            assertEquals(expectedPageSize, actualParams.hitsPerPage)
+        }
+    }
+
+    @Test
+    @DisplayName("Should apply default sort parameters when no sort provided")
+    fun shouldApplyDefaultSortParameters_whenNoSortProvided() {
+        // given
+        val page = Page(2, 10)
+        val sort = Sort(null, null)
+        whenever(userService.getCurrentUser()).thenReturn(createUser())
+        val searchResponse = SearchResponse<DocumentResultData>()
+        whenever(searchClient.searchSingleIndex(any(), any(), eq(DocumentResultData::class.java)))
+            .thenReturn(searchResponse)
+
+        // when
+        algoliaDocumentSearchService.search("", page, sort)
+
+        // then
+        verify(searchClient).searchSingleIndex(eq("documents"), any(), eq(DocumentResultData::class.java))
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideSortParameters")
+    @DisplayName("Should apply sort parameters when sort provided")
+    fun shouldApplySortParameters_whenSortProvided(
+        sortField: String, sortDirection: SortDirection,
+        expectedIndex: String
+    ) {
+        // given
+        val page = Page(2, 10)
+        val sort = Sort(sortField, sortDirection)
+        whenever(userService.getCurrentUser()).thenReturn(createUser())
+        val searchResponse = SearchResponse<DocumentResultData>()
+        whenever(searchClient.searchSingleIndex(any(), any(), eq(DocumentResultData::class.java)))
+            .thenReturn(searchResponse)
+
+        // when
+        algoliaDocumentSearchService.search("", page, sort)
+
+        // then
+        verify(searchClient).searchSingleIndex(eq(expectedIndex), any(), eq(DocumentResultData::class.java))
+    }
+
+    private fun createUser(): UserEntity {
+        return UserEntity().apply {
+            id = 1L
+            name = "name"
+            uid = "test@test.org"
+        }
+    }
+
+    private fun createSearchResult(): SearchResponse<DocumentResultData> {
+        return SearchResponse<DocumentResultData>().apply {
+            hits = listOf()
+            nbHits = 57
+            page = 3
+            nbPages = 16
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        private fun provideSortParameters(): Stream<Arguments> =
+            Stream.of(
+                Arguments.of("createdDate", SortDirection.ASC, "documents_createdDateTs_asc"),
+                Arguments.of("createdDate", SortDirection.DESC, "documents_createdDateTs_desc"),
+                Arguments.of("modifiedDate", SortDirection.ASC, "documents_modifiedDateTs_asc"),
+                Arguments.of("modifiedDate", SortDirection.DESC, "documents_modifiedDateTs_desc"),
+                Arguments.of("fileName", SortDirection.ASC, "documents_fileName_asc"),
+                Arguments.of("fileName", SortDirection.DESC, "documents_fileName_desc"),
+                Arguments.of("name", SortDirection.ASC, "documents_name_asc"),
+                Arguments.of("name", SortDirection.DESC, "documents_name_desc"),
+                Arguments.of("another", SortDirection.ASC, "documents"),
+            )
+    }
 }

--- a/src/test/kotlin/org/hkurh/doky/search/index/impl/AlgoliaIndexServiceTest.kt
+++ b/src/test/kotlin/org/hkurh/doky/search/index/impl/AlgoliaIndexServiceTest.kt
@@ -1,0 +1,222 @@
+/*
+ * This file is part of the Doky Project.
+ *
+ * Copyright (C) 2022-2026
+ *  - Hanna Kurhuzenkava (hanna.kurhuzenkava@outlook.com)
+ *  - Anton Kurhuzenkau (kurguzenkov@gmail.com)
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If not, see https://www.gnu.org/licenses/gpl-3.0.en.html.
+ *
+ * Contact Information:
+ *  - Project Homepage: https://github.com/hanna-eismant/doky
+ */
+
+package org.hkurh.doky.search.index.impl
+
+import com.algolia.api.SearchClient
+import com.algolia.model.search.BatchResponse
+import com.algolia.model.search.SaveObjectResponse
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.SoftAssertions.assertSoftly
+import org.hkurh.doky.DokyUnitTest
+import org.hkurh.doky.documents.DocumentAccessService
+import org.hkurh.doky.documents.db.DocumentEntity
+import org.hkurh.doky.documents.db.DocumentEntityRepository
+import org.hkurh.doky.search.DocumentIndexData
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.inOrder
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import java.util.*
+
+@DisplayName("AlgoliaIndexService unit test")
+class AlgoliaIndexServiceTest : DokyUnitTest {
+
+    private val documentEntityRepository: DocumentEntityRepository = mock()
+    private val documentAccessService: DocumentAccessService = mock()
+    private val searchClient: SearchClient = mock()
+    private val indexName: String = "documents"
+
+    private val indexService =
+        AlgoliaIndexService(documentEntityRepository, documentAccessService, searchClient, indexName)
+
+
+    @Test
+    @DisplayName("Should clear before do full index")
+    fun shouldClearAllBeforeFullIndex() {
+        // when
+        indexService.fullIndex()
+
+        // then
+        val searchClientInOrder = inOrder(searchClient)
+        searchClientInOrder.verify(searchClient).clearObjects(indexName)
+        searchClientInOrder.verify(searchClient).saveObjects(eq(indexName), any<List<DocumentIndexData>>())
+    }
+
+    @Test
+    @DisplayName("Should populate allowed users when do full index")
+    fun shouldPopulateAllowedUsers_whenFullIndex() {
+        // given
+        val documentEntities = createDocumentEntities()
+        whenever(documentEntityRepository.findAll()).thenReturn(documentEntities)
+
+        // when
+        indexService.fullIndex()
+
+        // then
+        val captor = argumentCaptor<DocumentIndexData>()
+        verify(documentAccessService, times(2))
+            .populateAllowedUsers(captor.capture())
+        val capturedArgs = captor.allValues
+        assert(capturedArgs.size == 2)
+        assert(capturedArgs[0].objectID == "1")
+        assert(capturedArgs[1].objectID == "2")
+    }
+
+    @Test
+    @DisplayName("Should send all documents to index")
+    fun shouldSendAllDocumentsToIndex() {
+        // given
+        val documentEntities = createDocumentEntities()
+        whenever(documentEntityRepository.findAll()).thenReturn(documentEntities)
+        whenever(documentAccessService.populateAllowedUsers(any())).thenAnswer { invocation ->
+            val arg = invocation.arguments[0] as DocumentIndexData
+            arg.allowedUsers = mutableListOf("user-${arg.objectID}")
+            arg
+        }
+
+        // when
+        indexService.fullIndex()
+
+        // then
+        val captor = argumentCaptor<List<DocumentIndexData>>()
+        verify(searchClient).saveObjects(eq(indexName), captor.capture())
+        val savedDocs = captor.firstValue
+        assertSoftly {
+            assertThat(savedDocs).hasSize(2)
+            assertThat(savedDocs[0].allowedUsers).containsExactly("user-1")
+            assertThat(savedDocs[0].objectID).isEqualTo("1")
+            assertThat(savedDocs[1].allowedUsers).containsExactly("user-2")
+            assertThat(savedDocs[1].objectID).isEqualTo("2")
+        }
+    }
+
+    @Test
+    @DisplayName("Should wait until full index finished")
+    fun shouldWaitUntilFullIndexFinished() {
+        // given
+        whenever(searchClient.saveObjects(eq(indexName), any<List<DocumentIndexData>>()))
+            .thenReturn(createBatchResponseOk())
+
+        // when
+        indexService.fullIndex()
+
+        // then
+        verify(searchClient).waitForTask(eq(indexName), eq(1))
+    }
+
+    @Test
+    @DisplayName("Should do nothing when no document for update")
+    fun shouldDoNothing_whenNoDocumentForUpdate() {
+        // when
+        indexService.updateIndex(1)
+
+        // then
+        verifyNoInteractions(documentAccessService, searchClient)
+    }
+
+    @Test
+    @DisplayName("Should populate allowed users when update document in index")
+    fun shouldPopulateAllowedUsers_whenUpdateDocument() {
+        // given
+        val docId = 1L
+        val doc = DocumentEntity().apply { id = docId }
+        whenever(documentEntityRepository.findById(docId)).thenReturn(Optional.of(doc))
+        whenever(searchClient.saveObject(eq(indexName), any<DocumentIndexData>())).thenReturn(createSaveResponseOk())
+
+        // when
+        indexService.updateIndex(docId)
+
+        // then
+        val captor = argumentCaptor<DocumentIndexData>()
+        verify(documentAccessService).populateAllowedUsers(captor.capture())
+        val capturedArgs = captor.allValues
+        assert(capturedArgs[0].objectID == "1")
+    }
+
+    @Test
+    @DisplayName("Should send document to index")
+    fun shouldSendDocumentToIndex() {
+        // given
+        val docId = 1L
+        val doc = DocumentEntity().apply { id = docId }
+        whenever(documentEntityRepository.findById(docId)).thenReturn(Optional.of(doc))
+        whenever(documentAccessService.populateAllowedUsers(any())).thenAnswer { invocation ->
+            val arg = invocation.arguments[0] as DocumentIndexData
+            arg.allowedUsers = mutableListOf("user-${arg.objectID}")
+            arg
+        }
+        whenever(searchClient.saveObject(eq(indexName), any<DocumentIndexData>())).thenReturn(createSaveResponseOk())
+
+        // when
+        indexService.updateIndex(docId)
+
+        // then
+        val captor = argumentCaptor<DocumentIndexData>()
+        verify(searchClient).saveObject(eq(indexName), captor.capture())
+        val savedDoc = captor.firstValue
+        assertSoftly {
+            assertThat(savedDoc.allowedUsers).containsExactly("user-1")
+            assertThat(savedDoc.objectID).isEqualTo("1")
+        }
+    }
+
+    @Test
+    @DisplayName("Should wait until document update finished")
+    fun shouldWaitUntilDocumentUpdateFinished() {
+        // given
+        val docId = 1L
+        val doc = DocumentEntity().apply { id = docId }
+        whenever(documentEntityRepository.findById(docId)).thenReturn(Optional.of(doc))
+        whenever(searchClient.saveObject(eq(indexName), any<DocumentIndexData>())).thenReturn(createSaveResponseOk())
+
+        // when
+        indexService.updateIndex(docId)
+
+        // then
+        verify(searchClient).waitForTask(eq(indexName), eq(1))
+    }
+
+    private fun createDocumentEntities(): List<DocumentEntity> {
+        val doc1 = DocumentEntity().apply { id = 1 }
+        val doc2 = DocumentEntity().apply { id = 2 }
+
+        return listOf(doc1, doc2)
+    }
+
+    private fun createBatchResponseOk(): List<BatchResponse> {
+        val response = BatchResponse().apply {
+            taskID = 1
+        }
+        return listOf(response)
+    }
+
+    private fun createSaveResponseOk(): SaveObjectResponse {
+        return SaveObjectResponse().apply {
+            taskID = 1
+        }
+    }
+}


### PR DESCRIPTION
- Add unit tests for Algolia services.
- Updated `DefaultPasswordTokenService` to use `Clock` for time-based calculations.
- Introduced `TimeConfig` for centralizing `Clock` bean configuration.
- Enhanced `DefaultResetPasswordService` and `DefaultJwtProvider` to rely on `Clock` for consistent UTC date handling.
- Replaced old `DateTime` logic with `LocalDateTime` and extension functions for UTC conversion.
- Improved unit tests to utilize fixed `Clock` for deterministic expiration time testing.
- Added tests for token expiration and user retrieval logic.
- Refactored token-related interfaces and classes for clarity (`TokenService` to `PasswordTokenService`).